### PR TITLE
Use std::io::Error instead of own error type

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,21 +3,38 @@ use std::fmt;
 use std::io;
 use std::path::PathBuf;
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum ErrorKind {
+    OpenFile,
+    CreateFile,
+    SyncFile,
+    SetLen,
+    Metadata,
+    Clone,
+    SetPermissions,
+    Read,
+    Seek,
+    Write,
+    Flush,
+}
+
 /// Contains an IO error that has a file path attached.
 ///
 /// This type is never returned directly, but is instead wrapped inside yet
 /// another IO error.
 #[derive(Debug)]
 pub(crate) struct Error {
+    kind: ErrorKind,
     source: io::Error,
     path: PathBuf,
 }
 
 impl Error {
-    pub fn new<P: Into<PathBuf>>(source: io::Error, path: P) -> io::Error {
+    pub fn new<P: Into<PathBuf>>(source: io::Error, kind: ErrorKind, path: P) -> io::Error {
         io::Error::new(
             source.kind(),
             Self {
+                kind,
                 source,
                 path: path.into(),
             },
@@ -27,7 +44,23 @@ impl Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "{} in path {}", self.source, self.path.display())
+        use ErrorKind::*;
+
+        let path = self.path.display();
+
+        match self.kind {
+            OpenFile => write!(formatter, "failed to open file `{}`", path),
+            CreateFile => write!(formatter, "failed to create file `{}`", path),
+            SyncFile => write!(formatter, "failed to sync file `{}`", path),
+            SetLen => write!(formatter, "failed to set length of file `{}`", path),
+            Metadata => write!(formatter, "failed to query metadata of file `{}`", path),
+            Clone => write!(formatter, "failed to clone handle for file `{}`", path),
+            SetPermissions => write!(formatter, "failed to set permissions for file `{}`", path),
+            Read => write!(formatter, "failed to read from file `{}`", path),
+            Seek => write!(formatter, "failed to seek in file `{}`", path),
+            Write => write!(formatter, "failed to write to file `{}`", path),
+            Flush => write!(formatter, "failed to flush file `{}`", path),
+        }
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,81 @@
+use std::error::Error as StdError;
+use std::fmt;
+use std::io;
+use std::path::PathBuf;
+
+/// Contains an IO error that has a file path attached.
+///
+/// This type is never returned directly, but is instead wrapped inside yet
+/// another IO error.
+#[derive(Debug)]
+pub(crate) struct Error {
+    source: io::Error,
+    path: PathBuf,
+}
+
+impl Error {
+    pub fn new<P: Into<PathBuf>>(source: io::Error, path: P) -> io::Error {
+        io::Error::new(
+            source.kind(),
+            Self {
+                source,
+                path: path.into(),
+            },
+        )
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "{} in path {}", self.source, self.path.display())
+    }
+}
+
+impl StdError for Error {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        Some(&self.source)
+    }
+}
+
+/// Contains an IO error from a copy operation, containing both paths.
+#[derive(Debug)]
+pub(crate) struct CopyError {
+    source: io::Error,
+    source_path: PathBuf,
+    dest_path: PathBuf,
+}
+
+impl CopyError {
+    pub fn new<P: Into<PathBuf>, Q: Into<PathBuf>>(
+        source: io::Error,
+        source_path: P,
+        dest_path: Q,
+    ) -> io::Error {
+        io::Error::new(
+            source.kind(),
+            Self {
+                source,
+                source_path: source_path.into(),
+                dest_path: dest_path.into(),
+            },
+        )
+    }
+}
+
+impl fmt::Display for CopyError {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            formatter,
+            "{} copying path {} to {}",
+            self.source,
+            self.source_path.display(),
+            self.dest_path.display()
+        )
+    }
+}
+
+impl StdError for CopyError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        Some(&self.source)
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -32,49 +32,10 @@ impl fmt::Display for Error {
 }
 
 impl StdError for Error {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        Some(&self.source)
+    fn cause(&self) -> Option<&dyn StdError> {
+        self.source()
     }
-}
 
-/// Contains an IO error from a copy operation, containing both paths.
-#[derive(Debug)]
-pub(crate) struct CopyError {
-    source: io::Error,
-    source_path: PathBuf,
-    dest_path: PathBuf,
-}
-
-impl CopyError {
-    pub fn new<P: Into<PathBuf>, Q: Into<PathBuf>>(
-        source: io::Error,
-        source_path: P,
-        dest_path: Q,
-    ) -> io::Error {
-        io::Error::new(
-            source.kind(),
-            Self {
-                source,
-                source_path: source_path.into(),
-                dest_path: dest_path.into(),
-            },
-        )
-    }
-}
-
-impl fmt::Display for CopyError {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            formatter,
-            "{} copying path {} to {}",
-            self.source,
-            self.source_path.display(),
-            self.dest_path.display()
-        )
-    }
-}
-
-impl StdError for CopyError {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         Some(&self.source)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@
 #![doc(html_root_url = "https://docs.rs/fs-err/1.0.1")]
 #![deny(missing_debug_implementations, missing_docs)]
 
+mod errors;
+
 use std::fmt;
 use std::io::{Read, Seek, Write};
 use std::path::{self, Path, PathBuf};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use std::fs;
 use std::io::{self, Read, Seek, Write};
 use std::path::{Path, PathBuf};
 
-use errors::Error;
+use errors::{Error, ErrorKind};
 
 /// A wrapper around a file handle and its path which wraps all
 /// operations with more helpful error messages.
@@ -29,7 +29,7 @@ impl File {
     {
         match fs::File::open(path.as_ref()) {
             Ok(file) => Ok(File::from_parts(file, path.into())),
-            Err(source) => Err(Error::new(source, path)),
+            Err(source) => Err(Error::new(source, ErrorKind::OpenFile, path)),
         }
     }
 
@@ -40,7 +40,7 @@ impl File {
     {
         match fs::File::create(path.as_ref()) {
             Ok(file) => Ok(File::from_parts(file, path.into())),
-            Err(source) => Err(Error::new(source, path)),
+            Err(source) => Err(Error::new(source, ErrorKind::CreateFile, path)),
         }
     }
 
@@ -51,7 +51,7 @@ impl File {
     {
         match options.open(path.as_ref()) {
             Ok(file) => Ok(File::from_parts(file, path.into())),
-            Err(source) => Err(Error::new(source, path)),
+            Err(source) => Err(Error::new(source, ErrorKind::OpenFile, path)),
         }
     }
 
@@ -59,28 +59,28 @@ impl File {
     pub fn sync_all(&self) -> Result<(), io::Error> {
         self.file
             .sync_all()
-            .map_err(|source| Error::new(source, &self.path))
+            .map_err(|source| self.error(source, ErrorKind::SyncFile))
     }
 
     /// Wrapper for [`File::sync_data`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.sync_data).
     pub fn sync_data(&self) -> Result<(), io::Error> {
         self.file
             .sync_data()
-            .map_err(|source| Error::new(source, &self.path))
+            .map_err(|source| self.error(source, ErrorKind::SyncFile))
     }
 
     /// Wrapper for [`File::set_len`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.set_len).
     pub fn set_len(&self, size: u64) -> Result<(), io::Error> {
         self.file
             .set_len(size)
-            .map_err(|source| Error::new(source, &self.path))
+            .map_err(|source| self.error(source, ErrorKind::SetLen))
     }
 
     /// Wrapper for [`File::metadata`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.metadata).
     pub fn metadata(&self) -> Result<fs::Metadata, io::Error> {
         self.file
             .metadata()
-            .map_err(|source| Error::new(source, &self.path))
+            .map_err(|source| self.error(source, ErrorKind::Metadata))
     }
 
     /// Wrapper for [`File::try_clone`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.try_clone).
@@ -91,14 +91,14 @@ impl File {
                 file,
                 path: self.path.clone(),
             })
-            .map_err(|source| Error::new(source, &self.path))
+            .map_err(|source| self.error(source, ErrorKind::Clone))
     }
 
     /// Wrapper for [`File::set_permissions`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.set_permissions).
     pub fn set_permissions(&self, perm: fs::Permissions) -> Result<(), io::Error> {
         self.file
             .set_permissions(perm)
-            .map_err(|source| Error::new(source, &self.path))
+            .map_err(|source| self.error(source, ErrorKind::SetPermissions))
     }
 
     /// Creates a [`File`](struct.File.html) from a raw file and its
@@ -122,19 +122,24 @@ impl File {
     pub fn path(&self) -> &Path {
         &self.path
     }
+
+    /// Wrap the error in information specific to this `File` object.
+    fn error(&self, source: io::Error, kind: ErrorKind) -> io::Error {
+        Error::new(source, kind, &self.path)
+    }
 }
 
 impl Read for File {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         self.file
             .read(buf)
-            .map_err(|source| Error::new(source, &self.path))
+            .map_err(|source| self.error(source, ErrorKind::Read))
     }
 
     fn read_vectored(&mut self, bufs: &mut [std::io::IoSliceMut<'_>]) -> std::io::Result<usize> {
         self.file
             .read_vectored(bufs)
-            .map_err(|source| Error::new(source, &self.path))
+            .map_err(|source| self.error(source, ErrorKind::Read))
     }
 }
 
@@ -142,13 +147,13 @@ impl<'a> Read for &'a File {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         (&(**self).file)
             .read(buf)
-            .map_err(|source| Error::new(source, &self.path))
+            .map_err(|source| self.error(source, ErrorKind::Read))
     }
 
     fn read_vectored(&mut self, bufs: &mut [std::io::IoSliceMut<'_>]) -> std::io::Result<usize> {
         (&(**self).file)
             .read_vectored(bufs)
-            .map_err(|source| Error::new(source, &self.path))
+            .map_err(|source| self.error(source, ErrorKind::Read))
     }
 }
 
@@ -156,7 +161,7 @@ impl Seek for File {
     fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
         self.file
             .seek(pos)
-            .map_err(|source| Error::new(source, &self.path))
+            .map_err(|source| self.error(source, ErrorKind::Seek))
     }
 }
 
@@ -164,7 +169,7 @@ impl<'a> Seek for &'a File {
     fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
         (&(**self).file)
             .seek(pos)
-            .map_err(|source| Error::new(source, &self.path))
+            .map_err(|source| self.error(source, ErrorKind::Seek))
     }
 }
 
@@ -172,19 +177,19 @@ impl Write for File {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         self.file
             .write(buf)
-            .map_err(|source| Error::new(source, &self.path))
+            .map_err(|source| self.error(source, ErrorKind::Write))
     }
 
     fn write_vectored(&mut self, bufs: &[std::io::IoSlice<'_>]) -> std::io::Result<usize> {
         self.file
             .write_vectored(bufs)
-            .map_err(|source| Error::new(source, &self.path))
+            .map_err(|source| self.error(source, ErrorKind::Write))
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
         self.file
             .flush()
-            .map_err(|source| Error::new(source, &self.path))
+            .map_err(|source| self.error(source, ErrorKind::Flush))
     }
 }
 
@@ -192,36 +197,49 @@ impl<'a> Write for &'a File {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         (&(**self).file)
             .write(buf)
-            .map_err(|source| Error::new(source, &self.path))
+            .map_err(|source| self.error(source, ErrorKind::Write))
     }
 
     fn write_vectored(&mut self, bufs: &[std::io::IoSlice<'_>]) -> std::io::Result<usize> {
         (&(**self).file)
             .write_vectored(bufs)
-            .map_err(|source| Error::new(source, &self.path))
+            .map_err(|source| self.error(source, ErrorKind::Write))
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
         (&(**self).file)
             .flush()
-            .map_err(|source| Error::new(source, &self.path))
+            .map_err(|source| self.error(source, ErrorKind::Flush))
     }
 }
 
+fn initial_buffer_size(file: &File) -> usize {
+    file.file()
+        .metadata()
+        .map(|m| m.len() as usize + 1)
+        .unwrap_or(0)
+}
+
 /// Wrapper for [`fs::read`](https://doc.rust-lang.org/stable/std/fs/fn.read.html).
-pub fn read<P: AsRef<Path> + Into<PathBuf>>(path: P) -> std::io::Result<Vec<u8>> {
-    fs::read(path.as_ref()).map_err(|source| Error::new(source, path))
+pub fn read<P: AsRef<Path> + Into<PathBuf>>(path: P) -> io::Result<Vec<u8>> {
+    let mut file = File::open(path)?;
+    let mut bytes = Vec::with_capacity(initial_buffer_size(&file));
+    file.read_to_end(&mut bytes)?;
+    Ok(bytes)
 }
 
 /// Wrapper for [`fs::read_to_string`](https://doc.rust-lang.org/stable/std/fs/fn.read_to_string.html).
-pub fn read_to_string<P: AsRef<Path> + Into<PathBuf>>(path: P) -> std::io::Result<String> {
-    fs::read_to_string(path.as_ref()).map_err(|source| Error::new(source, path))
+pub fn read_to_string<P: AsRef<Path> + Into<PathBuf>>(path: P) -> io::Result<String> {
+    let mut file = File::open(path)?;
+    let mut string = String::with_capacity(initial_buffer_size(&file));
+    file.read_to_string(&mut string)?;
+    Ok(string)
 }
 
 /// Wrapper for [`fs::write`](https://doc.rust-lang.org/stable/std/fs/fn.write.html).
 pub fn write<P: AsRef<Path> + Into<PathBuf>, C: AsRef<[u8]>>(
     path: P,
     contents: C,
-) -> std::io::Result<()> {
-    fs::write(path.as_ref(), contents).map_err(|source| Error::new(source, path))
+) -> io::Result<()> {
+    File::create(path)?.write_all(contents.as_ref())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 
 mod errors;
 
+use std::fs;
 use std::io::{self, Read, Seek, Write};
 use std::path::{Path, PathBuf};
 
@@ -16,7 +17,7 @@ use errors::Error;
 /// operations with more helpful error messages.
 #[derive(Debug)]
 pub struct File {
-    file: std::fs::File,
+    file: fs::File,
     path: PathBuf,
 }
 
@@ -26,7 +27,7 @@ impl File {
     where
         P: AsRef<Path> + Into<PathBuf>,
     {
-        match std::fs::File::open(path.as_ref()) {
+        match fs::File::open(path.as_ref()) {
             Ok(file) => Ok(File::from_parts(file, path.into())),
             Err(source) => Err(Error::new(source, path)),
         }
@@ -37,14 +38,14 @@ impl File {
     where
         P: AsRef<Path> + Into<PathBuf>,
     {
-        match std::fs::File::create(path.as_ref()) {
+        match fs::File::create(path.as_ref()) {
             Ok(file) => Ok(File::from_parts(file, path.into())),
             Err(source) => Err(Error::new(source, path)),
         }
     }
 
     /// Wrapper for [`OpenOptions::open`](https://doc.rust-lang.org/stable/std/fs/struct.OpenOptions.html#method.open).
-    pub fn from_options<P>(path: P, options: &std::fs::OpenOptions) -> Result<Self, io::Error>
+    pub fn from_options<P>(path: P, options: &fs::OpenOptions) -> Result<Self, io::Error>
     where
         P: AsRef<Path> + Into<PathBuf>,
     {
@@ -76,7 +77,7 @@ impl File {
     }
 
     /// Wrapper for [`File::metadata`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.metadata).
-    pub fn metadata(&self) -> Result<std::fs::Metadata, io::Error> {
+    pub fn metadata(&self) -> Result<fs::Metadata, io::Error> {
         self.file
             .metadata()
             .map_err(|source| Error::new(source, &self.path))
@@ -94,7 +95,7 @@ impl File {
     }
 
     /// Wrapper for [`File::set_permissions`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.set_permissions).
-    pub fn set_permissions(&self, perm: std::fs::Permissions) -> Result<(), io::Error> {
+    pub fn set_permissions(&self, perm: fs::Permissions) -> Result<(), io::Error> {
         self.file
             .set_permissions(perm)
             .map_err(|source| Error::new(source, &self.path))
@@ -102,7 +103,7 @@ impl File {
 
     /// Creates a [`File`](struct.File.html) from a raw file and its
     /// path.
-    pub fn from_parts<P>(file: std::fs::File, path: P) -> Self
+    pub fn from_parts<P>(file: fs::File, path: P) -> Self
     where
         P: Into<PathBuf>,
     {
@@ -113,7 +114,7 @@ impl File {
     }
 
     /// Gets the wrapped file.
-    pub fn file(&self) -> &std::fs::File {
+    pub fn file(&self) -> &fs::File {
         &self.file
     }
 
@@ -209,12 +210,12 @@ impl<'a> Write for &'a File {
 
 /// Wrapper for [`fs::read`](https://doc.rust-lang.org/stable/std/fs/fn.read.html).
 pub fn read<P: AsRef<Path> + Into<PathBuf>>(path: P) -> std::io::Result<Vec<u8>> {
-    std::fs::read(path.as_ref()).map_err(|source| Error::new(source, path))
+    fs::read(path.as_ref()).map_err(|source| Error::new(source, path))
 }
 
 /// Wrapper for [`fs::read_to_string`](https://doc.rust-lang.org/stable/std/fs/fn.read_to_string.html).
 pub fn read_to_string<P: AsRef<Path> + Into<PathBuf>>(path: P) -> std::io::Result<String> {
-    std::fs::read_to_string(path.as_ref()).map_err(|source| Error::new(source, path))
+    fs::read_to_string(path.as_ref()).map_err(|source| Error::new(source, path))
 }
 
 /// Wrapper for [`fs::write`](https://doc.rust-lang.org/stable/std/fs/fn.write.html).
@@ -222,11 +223,5 @@ pub fn write<P: AsRef<Path> + Into<PathBuf>, C: AsRef<[u8]>>(
     path: P,
     contents: C,
 ) -> std::io::Result<()> {
-    std::fs::write(path.as_ref(), contents).map_err(|source| Error::new(source, path))
-}
-
-#[test]
-fn open() {
-    let err = File::open("doesn't exist").unwrap_err();
-    assert_eq!(format!("{}", err), "failed to open file `doesn't exist`");
+    fs::write(path.as_ref(), contents).map_err(|source| Error::new(source, path))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,10 @@
 
 mod errors;
 
-use std::fmt;
-use std::io::{Read, Seek, Write};
-use std::path::{self, Path, PathBuf};
+use std::io::{self, Read, Seek, Write};
+use std::path::{Path, PathBuf};
+
+use errors::Error;
 
 /// A wrapper around a file handle and its path which wraps all
 /// operations with more helpful error messages.
@@ -19,107 +20,84 @@ pub struct File {
     path: PathBuf,
 }
 
-/// A wrapper around a `std::io::Error` from a filesystem operation,
-/// with context including the path of the associated file.
-#[derive(Debug)]
-pub struct Error {
-    source: std::io::Error,
-    message: String,
-}
-
 impl File {
     /// Wrapper for [`File::open`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.open).
-    pub fn open<P>(path: P) -> Result<Self, Error>
+    pub fn open<P>(path: P) -> Result<Self, io::Error>
     where
         P: AsRef<Path> + Into<PathBuf>,
     {
         match std::fs::File::open(path.as_ref()) {
             Ok(file) => Ok(File::from_parts(file, path.into())),
-            Err(error) => Err(Error::new(
-                error,
-                format!("failed to open file `{}`", path.as_ref().display()),
-            )),
+            Err(source) => Err(Error::new(source, path)),
         }
     }
 
     /// Wrapper for [`File::create`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.create).
-    pub fn create<P>(path: P) -> Result<Self, Error>
+    pub fn create<P>(path: P) -> Result<Self, io::Error>
     where
         P: AsRef<Path> + Into<PathBuf>,
     {
-        match std::fs::File::open(path.as_ref()) {
+        match std::fs::File::create(path.as_ref()) {
             Ok(file) => Ok(File::from_parts(file, path.into())),
-            Err(error) => Err(Error::new(
-                error,
-                format!("failed to create file `{}`", path.as_ref().display()),
-            )),
+            Err(source) => Err(Error::new(source, path)),
         }
     }
 
     /// Wrapper for [`OpenOptions::open`](https://doc.rust-lang.org/stable/std/fs/struct.OpenOptions.html#method.open).
-    pub fn from_options<P>(path: P, options: &std::fs::OpenOptions) -> Result<Self, Error>
+    pub fn from_options<P>(path: P, options: &std::fs::OpenOptions) -> Result<Self, io::Error>
     where
         P: AsRef<Path> + Into<PathBuf>,
     {
         match options.open(path.as_ref()) {
             Ok(file) => Ok(File::from_parts(file, path.into())),
-            Err(error) => Err(Error::new(
-                error,
-                format!("failed to open file `{}`", path.as_ref().display()),
-            )),
+            Err(source) => Err(Error::new(source, path)),
         }
     }
 
     /// Wrapper for [`File::sync_all`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.sync_all).
-    pub fn sync_all(&self) -> Result<(), Error> {
-        self.try_exec(
-            |file| file.sync_all(),
-            |path| format!("failed to synchronize file `{}`", path),
-        )
+    pub fn sync_all(&self) -> Result<(), io::Error> {
+        self.file
+            .sync_all()
+            .map_err(|source| Error::new(source, &self.path))
     }
 
     /// Wrapper for [`File::sync_data`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.sync_data).
-    pub fn sync_data(&self) -> Result<(), Error> {
-        self.try_exec(
-            |file| file.sync_data(),
-            |path| format!("failed to synchronize file `{}`", path),
-        )
+    pub fn sync_data(&self) -> Result<(), io::Error> {
+        self.file
+            .sync_data()
+            .map_err(|source| Error::new(source, &self.path))
     }
 
     /// Wrapper for [`File::set_len`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.set_len).
-    pub fn set_len(&self, size: u64) -> Result<(), Error> {
-        self.try_exec(
-            |file| file.set_len(size),
-            |path| format!("failed to set length for file `{}`", path),
-        )
+    pub fn set_len(&self, size: u64) -> Result<(), io::Error> {
+        self.file
+            .set_len(size)
+            .map_err(|source| Error::new(source, &self.path))
     }
 
     /// Wrapper for [`File::metadata`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.metadata).
-    pub fn metadata(&self) -> Result<std::fs::Metadata, Error> {
-        self.try_exec(
-            |file| file.metadata(),
-            |path| format!("failed to query metadata for file `{}`", path),
-        )
+    pub fn metadata(&self) -> Result<std::fs::Metadata, io::Error> {
+        self.file
+            .metadata()
+            .map_err(|source| Error::new(source, &self.path))
     }
 
     /// Wrapper for [`File::try_clone`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.try_clone).
-    pub fn try_clone(&self) -> Result<File, Error> {
-        let file = self.try_exec(
-            |file| file.try_clone(),
-            |path| format!("failed to clone handle for file `{}`", path),
-        )?;
-        Ok(File {
-            file,
-            path: self.path.clone(),
-        })
+    pub fn try_clone(&self) -> Result<Self, io::Error> {
+        self.file
+            .try_clone()
+            .map(|file| File {
+                file,
+                path: self.path.clone(),
+            })
+            .map_err(|source| Error::new(source, &self.path))
     }
 
     /// Wrapper for [`File::set_permissions`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.set_permissions).
-    pub fn set_permissions(&self, perm: std::fs::Permissions) -> Result<(), Error> {
-        self.try_exec(
-            |file| file.set_permissions(perm),
-            |path| format!("failed to set permissions for file `{}`", path),
-        )
+    pub fn set_permissions(&self, perm: std::fs::Permissions) -> Result<(), io::Error> {
+        self.file
+            .set_permissions(perm)
+            .map_err(|source| Error::new(source, &self.path))
     }
 
     /// Creates a [`File`](struct.File.html) from a raw file and its
@@ -143,163 +121,100 @@ impl File {
     pub fn path(&self) -> &Path {
         &self.path
     }
-
-    fn try_exec<R>(
-        &self,
-        op: impl FnOnce(&std::fs::File) -> std::io::Result<R>,
-        context: impl FnOnce(&path::Display) -> String,
-    ) -> Result<R, Error> {
-        match op(&self.file) {
-            Ok(result) => Ok(result),
-            Err(error) => Err(Error::new(error, context(&self.path.display()))),
-        }
-    }
 }
 
 impl Read for File {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        (&mut &*self).read(buf)
+        self.file
+            .read(buf)
+            .map_err(|source| Error::new(source, &self.path))
     }
 
     fn read_vectored(&mut self, bufs: &mut [std::io::IoSliceMut<'_>]) -> std::io::Result<usize> {
-        (&mut &*self).read_vectored(bufs)
+        self.file
+            .read_vectored(bufs)
+            .map_err(|source| Error::new(source, &self.path))
     }
 }
 
 impl<'a> Read for &'a File {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        self.try_exec(
-            |mut file| file.read(buf),
-            |path| format!("failed to read from file `{}`", path),
-        )
-        .map_err(Error::into_io_error)
+        (&(**self).file)
+            .read(buf)
+            .map_err(|source| Error::new(source, &self.path))
     }
 
     fn read_vectored(&mut self, bufs: &mut [std::io::IoSliceMut<'_>]) -> std::io::Result<usize> {
-        self.try_exec(
-            |mut file| file.read_vectored(bufs),
-            |path| format!("failed to read from file `{}`", path),
-        )
-        .map_err(Error::into_io_error)
+        (&(**self).file)
+            .read_vectored(bufs)
+            .map_err(|source| Error::new(source, &self.path))
     }
 }
 
 impl Seek for File {
     fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
-        (&mut &*self).seek(pos)
+        self.file
+            .seek(pos)
+            .map_err(|source| Error::new(source, &self.path))
     }
 }
 
 impl<'a> Seek for &'a File {
     fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
-        self.try_exec(
-            |mut file| file.seek(pos),
-            |path| format!("failed to seek in file `{}`", path),
-        )
-        .map_err(Error::into_io_error)
+        (&(**self).file)
+            .seek(pos)
+            .map_err(|source| Error::new(source, &self.path))
     }
 }
 
 impl Write for File {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        (&mut &*self).write(buf)
+        self.file
+            .write(buf)
+            .map_err(|source| Error::new(source, &self.path))
     }
 
     fn write_vectored(&mut self, bufs: &[std::io::IoSlice<'_>]) -> std::io::Result<usize> {
-        (&mut &*self).write_vectored(bufs)
+        self.file
+            .write_vectored(bufs)
+            .map_err(|source| Error::new(source, &self.path))
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
-        (&mut &*self).flush()
+        self.file
+            .flush()
+            .map_err(|source| Error::new(source, &self.path))
     }
 }
 
 impl<'a> Write for &'a File {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.try_exec(
-            |mut file| file.write(buf),
-            |path| format!("failed to write to file `{}`", path),
-        )
-        .map_err(Error::into_io_error)
+        (&(**self).file)
+            .write(buf)
+            .map_err(|source| Error::new(source, &self.path))
     }
 
     fn write_vectored(&mut self, bufs: &[std::io::IoSlice<'_>]) -> std::io::Result<usize> {
-        self.try_exec(
-            |mut file| file.write_vectored(bufs),
-            |path| format!("failed to write to file `{}`", path),
-        )
-        .map_err(Error::into_io_error)
+        (&(**self).file)
+            .write_vectored(bufs)
+            .map_err(|source| Error::new(source, &self.path))
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
-        self.try_exec(
-            |mut file| file.flush(),
-            |path| format!("failed to flush file `{}`", path),
-        )
-        .map_err(Error::into_io_error)
+        (&(**self).file)
+            .flush()
+            .map_err(|source| Error::new(source, &self.path))
     }
-}
-
-impl Error {
-    /// Constructs an [`Error`](struct.Error.html).
-    pub fn new(source: std::io::Error, message: String) -> Self {
-        Error { source, message }
-    }
-
-    /// Gets a reference to the raw error.
-    pub fn source(&self) -> &std::io::Error {
-        &self.source
-    }
-
-    /// Convert into an `io::Error`.
-    pub fn into_io_error(self) -> std::io::Error {
-        std::io::Error::new(self.source.kind(), self)
-    }
-}
-
-impl From<Error> for std::io::Error {
-    fn from(err: Error) -> std::io::Error {
-        err.into_io_error()
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.message.fmt(f)
-    }
-}
-
-impl std::error::Error for Error {
-    fn cause(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(self.source())
-    }
-
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(self.source())
-    }
-}
-
-fn initial_buffer_size(file: &File) -> usize {
-    file.file()
-        .metadata()
-        .map(|m| m.len() as usize + 1)
-        .unwrap_or(0)
 }
 
 /// Wrapper for [`fs::read`](https://doc.rust-lang.org/stable/std/fs/fn.read.html).
 pub fn read<P: AsRef<Path> + Into<PathBuf>>(path: P) -> std::io::Result<Vec<u8>> {
-    let mut file = File::open(path)?;
-    let mut bytes = Vec::with_capacity(initial_buffer_size(&file));
-    file.read_to_end(&mut bytes)?;
-    Ok(bytes)
+    std::fs::read(path.as_ref()).map_err(|source| Error::new(source, path))
 }
 
 /// Wrapper for [`fs::read_to_string`](https://doc.rust-lang.org/stable/std/fs/fn.read_to_string.html).
 pub fn read_to_string<P: AsRef<Path> + Into<PathBuf>>(path: P) -> std::io::Result<String> {
-    let mut file = File::open(path)?;
-    let mut string = String::with_capacity(initial_buffer_size(&file));
-    file.read_to_string(&mut string)?;
-    Ok(string)
+    std::fs::read_to_string(path.as_ref()).map_err(|source| Error::new(source, path))
 }
 
 /// Wrapper for [`fs::write`](https://doc.rust-lang.org/stable/std/fs/fn.write.html).
@@ -307,7 +222,7 @@ pub fn write<P: AsRef<Path> + Into<PathBuf>, C: AsRef<[u8]>>(
     path: P,
     contents: C,
 ) -> std::io::Result<()> {
-    File::create(path)?.write_all(contents.as_ref())
+    std::fs::write(path.as_ref(), contents).map_err(|source| Error::new(source, path))
 }
 
 #[test]


### PR DESCRIPTION
Closes #1.

This PR converts the crate's public functions to return `std::io::Error` instead of a custom error type. I introduced a new custom error type that's internal to the crate and then updated all interfaces to use it.

This is a breaking change!