### PR TITLE
Use GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        rust_version: [stable, "1.39.0"]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Setup Rust toolchain
+      run: rustup default ${{ matrix.rust_version }}
+
+    - name: Build
+      run: cargo build --all --verbose
+
+    - name: Run tests
+      run: cargo test --all --verbose
+
+    - name: Rustfmt and Clippy
+      run: |
+        cargo fmt -- --check
+        cargo clippy
+      if: matrix.rust_version == 'stable'


### PR DESCRIPTION
I noticed that this repository doesn't have CI yet! There aren't many tests written yet, but this should also catch issues from not running rustfmt or clippy, too.

What minimum Rust version does fs-err support? I picked 1.39.0 here because I pulled this job out of one of my projects, but I imagine this crate runs on much older Rust versions.