### PR TITLE
Add CopyError and implement fs::copy

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -73,3 +73,45 @@ impl StdError for Error {
         Some(&self.source)
     }
 }
+
+/// Error type used by `fs::copy` that holds two paths.
+#[derive(Debug)]
+pub(crate) struct CopyError {
+    source: io::Error,
+    from_path: PathBuf,
+    to_path: PathBuf,
+}
+
+impl CopyError {
+    pub fn new<P: Into<PathBuf>, Q: Into<PathBuf>>(source: io::Error, from: P, to: Q) -> io::Error {
+        io::Error::new(
+            source.kind(),
+            Self {
+                source,
+                from_path: from.into(),
+                to_path: to.into(),
+            },
+        )
+    }
+}
+
+impl fmt::Display for CopyError {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            formatter,
+            "failed to copy file from {} to {}",
+            self.from_path.display(),
+            self.to_path.display()
+        )
+    }
+}
+
+impl StdError for CopyError {
+    fn cause(&self) -> Option<&dyn StdError> {
+        self.source()
+    }
+
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        Some(&self.source)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use std::fs;
 use std::io::{self, Read, Seek, Write};
 use std::path::{Path, PathBuf};
 
-use errors::{Error, ErrorKind};
+use errors::{CopyError, Error, ErrorKind};
 
 /// A wrapper around a file handle and its path which wraps all
 /// operations with more helpful error messages.
@@ -242,4 +242,13 @@ pub fn write<P: AsRef<Path> + Into<PathBuf>, C: AsRef<[u8]>>(
     contents: C,
 ) -> io::Result<()> {
     File::create(path)?.write_all(contents.as_ref())
+}
+
+/// Wrapper for [`fs::copy`](https://doc.rust-lang.org/stable/std/fs/fn.copy.html).
+pub fn copy<P, Q>(from: P, to: Q) -> io::Result<u64>
+where
+    P: AsRef<Path> + Into<PathBuf>,
+    Q: AsRef<Path> + Into<PathBuf>,
+{
+    fs::copy(from.as_ref(), to.as_ref()).map_err(|source| CopyError::new(source, from, to))
 }


### PR DESCRIPTION
Closes #5.

This brings an equivalent API to `fs::copy` into fs-err. I added a new inner error type instead of expanding the existing error type since this is the only variant with two paths involved right now.