### PR TITLE
Documentation and marketing-speak

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fs-err"
-description = "A simple wrapper around filesystem operations to provide more helpful error messages."
+description = "A drop-in replacement for std::fs with more helpful error messages."
 version = "2.0.1"
 authors = ["Andrew Hickman <andrew.hickman1@sky.com>"]
 edition = "2018"
@@ -14,3 +14,4 @@ readme = "README.md"
 
 [dev-dependencies]
 version-sync = "0.8.1"
+serde_json = "1.0.48"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,67 @@
+<!--
+	This readme is created with https://github.com/livioribeiro/cargo-readme
+
+	Edit `src/lib.rs` and use `cargo readme > README.md` to update it.
+-->
+
 # fs-err
 
-A simple wrapper around filesystem operations to provide more helpful error messages.
+[![Crates.io](https://img.shields.io/crates/v/fs-err.svg)](https://crates.io/crates/fs-err)
+[![GitHub Actions](https://github.com/andrewhickman/fs-err/workflows/CI/badge.svg)](https://github.com/andrewhickman/fs-err/actions?query=workflow%3ACI)
+
+fs-err is a drop-in replacement for [`std::fs`][std::fs] that provides more
+helpful messages on errors. Extra information includes which operations was
+attmpted and any involved paths.
+
+## Basic Usage
+
+fs-err's API is the same as [`std::fs`], so migrating code to use it is easy.
+
+```rust
+// use std::fs;
+use fs_err as fs;
+
+let contents = fs::read_to_string("foo.txt")?;
+
+println!("Read foo.txt: {}", contents);
+
+```
+
+fs-err uses [`std::io::Error`][std::io::Error] for all errors. This helps fs-err
+compose well with traits from the standard library like
+[`std::io::Read`][std::io::Read] and crates that use them like
+[`serde_json`][serde_json]:
+
+```rust
+use fs_err::File;
+
+let file = File::open("my-config.json")?;
+
+// If an I/O error occurs inside serde_json, the error will include a file path
+// as well as what operation was being performed.
+let decoded: Vec<String> = serde_json::from_reader(file)?;
+
+println!("Program config: {:?}", decoded);
+
+```
+
+[std::fs]: https://doc.rust-lang.org/stable/std/fs/
+[std::io::Error]: https://doc.rust-lang.org/stable/std/io/struct.Error.html
+[std::io::Read]: https://doc.rust-lang.org/stable/std/io/trait.Read.html
+[serde_json]: https://crates.io/crates/serde_json
+
+## License
+
+Licensed under either of
+
+* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you, as defined in the Apache-2.0
+license, shall be dual licensed as above, without any additional terms or
+conditions.

--- a/README.md
+++ b/README.md
@@ -13,9 +13,30 @@ fs-err is a drop-in replacement for [`std::fs`][std::fs] that provides more
 helpful messages on errors. Extra information includes which operations was
 attmpted and any involved paths.
 
-## Basic Usage
+## Error Messages
 
-fs-err's API is the same as [`std::fs`], so migrating code to use it is easy.
+Using [`std::fs`][std::fs], if this code fails:
+
+```rust
+let file = File::open("does not exist.txt")?;
+```
+
+The error message that Rust gives you isn't very useful:
+
+```txt
+The system cannot find the file specified. (os error 2)
+```
+
+...but if we use fs-err instead, our error contains more actionable information:
+
+```txt
+failed to open file `does not exist.txt`
+    caused by: The system cannot find the file specified. (os error 2)
+```
+
+## Usage
+
+fs-err's API is the same as [`std::fs`][std::fs], so migrating code to use it is easy.
 
 ```rust
 // use std::fs;

--- a/README.tpl
+++ b/README.tpl
@@ -1,0 +1,28 @@
+<!--
+	This readme is created with https://github.com/livioribeiro/cargo-readme
+
+	Edit `src/lib.rs` and use `cargo readme > README.md` to update it.
+-->
+
+# {{crate}}
+
+[![Crates.io](https://img.shields.io/crates/v/fs-err.svg)](https://crates.io/crates/fs-err)
+[![GitHub Actions](https://github.com/andrewhickman/fs-err/workflows/CI/badge.svg)](https://github.com/andrewhickman/fs-err/actions?query=workflow%3ACI)
+
+{{readme}}
+
+## License
+
+Licensed under either of
+
+* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you, as defined in the Apache-2.0
+license, shall be dual licensed as above, without any additional terms or
+conditions.

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,0 +1,217 @@
+use std::fs;
+use std::io::{self, Read, Seek, Write};
+use std::path::{Path, PathBuf};
+
+use crate::errors::{Error, ErrorKind};
+
+/// Wrapper around [`std::fs::File`][std::fs::File] which adds more helpful
+/// information to all errors.
+///
+/// [std::fs::File]: https://doc.rust-lang.org/stable/std/fs/struct.File.html
+#[derive(Debug)]
+pub struct File {
+    file: fs::File,
+    path: PathBuf,
+}
+
+/// Wrappers for methods from [`std::fs::File`][std::fs::File].
+///
+/// [std::fs::File]: https://doc.rust-lang.org/stable/std/fs/struct.File.html
+impl File {
+    /// Wrapper for [`File::open`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.open).
+    pub fn open<P>(path: P) -> Result<Self, io::Error>
+    where
+        P: AsRef<Path> + Into<PathBuf>,
+    {
+        match fs::File::open(path.as_ref()) {
+            Ok(file) => Ok(File::from_parts(file, path.into())),
+            Err(source) => Err(Error::new(source, ErrorKind::OpenFile, path)),
+        }
+    }
+
+    /// Wrapper for [`File::create`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.create).
+    pub fn create<P>(path: P) -> Result<Self, io::Error>
+    where
+        P: AsRef<Path> + Into<PathBuf>,
+    {
+        match fs::File::create(path.as_ref()) {
+            Ok(file) => Ok(File::from_parts(file, path.into())),
+            Err(source) => Err(Error::new(source, ErrorKind::CreateFile, path)),
+        }
+    }
+
+    /// Wrapper for [`OpenOptions::open`](https://doc.rust-lang.org/stable/std/fs/struct.OpenOptions.html#method.open).
+    pub fn from_options<P>(path: P, options: &fs::OpenOptions) -> Result<Self, io::Error>
+    where
+        P: AsRef<Path> + Into<PathBuf>,
+    {
+        match options.open(path.as_ref()) {
+            Ok(file) => Ok(File::from_parts(file, path.into())),
+            Err(source) => Err(Error::new(source, ErrorKind::OpenFile, path)),
+        }
+    }
+
+    /// Wrapper for [`File::sync_all`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.sync_all).
+    pub fn sync_all(&self) -> Result<(), io::Error> {
+        self.file
+            .sync_all()
+            .map_err(|source| self.error(source, ErrorKind::SyncFile))
+    }
+
+    /// Wrapper for [`File::sync_data`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.sync_data).
+    pub fn sync_data(&self) -> Result<(), io::Error> {
+        self.file
+            .sync_data()
+            .map_err(|source| self.error(source, ErrorKind::SyncFile))
+    }
+
+    /// Wrapper for [`File::set_len`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.set_len).
+    pub fn set_len(&self, size: u64) -> Result<(), io::Error> {
+        self.file
+            .set_len(size)
+            .map_err(|source| self.error(source, ErrorKind::SetLen))
+    }
+
+    /// Wrapper for [`File::metadata`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.metadata).
+    pub fn metadata(&self) -> Result<fs::Metadata, io::Error> {
+        self.file
+            .metadata()
+            .map_err(|source| self.error(source, ErrorKind::Metadata))
+    }
+
+    /// Wrapper for [`File::try_clone`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.try_clone).
+    pub fn try_clone(&self) -> Result<Self, io::Error> {
+        self.file
+            .try_clone()
+            .map(|file| File {
+                file,
+                path: self.path.clone(),
+            })
+            .map_err(|source| self.error(source, ErrorKind::Clone))
+    }
+
+    /// Wrapper for [`File::set_permissions`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.set_permissions).
+    pub fn set_permissions(&self, perm: fs::Permissions) -> Result<(), io::Error> {
+        self.file
+            .set_permissions(perm)
+            .map_err(|source| self.error(source, ErrorKind::SetPermissions))
+    }
+
+    /// Creates a [`File`](struct.File.html) from a raw file and its path.
+    pub fn from_parts<P>(file: fs::File, path: P) -> Self
+    where
+        P: Into<PathBuf>,
+    {
+        File {
+            file,
+            path: path.into(),
+        }
+    }
+}
+
+/// Methods added by fs-err that are not available on
+/// [`std::fs::File`][std::fs::File].
+///
+/// [std::fs::File]: https://doc.rust-lang.org/stable/std/fs/struct.File.html
+impl File {
+    /// Returns a reference to the underlying [`std::fs::File`][std::fs::File].
+    ///
+    /// [std::fs::File]: https://doc.rust-lang.org/stable/std/fs/struct.File.html
+    pub fn file(&self) -> &fs::File {
+        &self.file
+    }
+
+    /// Returns a reference to the path that this file was created with.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Wrap the error in information specific to this `File` object.
+    fn error(&self, source: io::Error, kind: ErrorKind) -> io::Error {
+        Error::new(source, kind, &self.path)
+    }
+}
+
+impl Read for File {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.file
+            .read(buf)
+            .map_err(|source| self.error(source, ErrorKind::Read))
+    }
+
+    fn read_vectored(&mut self, bufs: &mut [std::io::IoSliceMut<'_>]) -> std::io::Result<usize> {
+        self.file
+            .read_vectored(bufs)
+            .map_err(|source| self.error(source, ErrorKind::Read))
+    }
+}
+
+impl<'a> Read for &'a File {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        (&(**self).file)
+            .read(buf)
+            .map_err(|source| self.error(source, ErrorKind::Read))
+    }
+
+    fn read_vectored(&mut self, bufs: &mut [std::io::IoSliceMut<'_>]) -> std::io::Result<usize> {
+        (&(**self).file)
+            .read_vectored(bufs)
+            .map_err(|source| self.error(source, ErrorKind::Read))
+    }
+}
+
+impl Seek for File {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        self.file
+            .seek(pos)
+            .map_err(|source| self.error(source, ErrorKind::Seek))
+    }
+}
+
+impl<'a> Seek for &'a File {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        (&(**self).file)
+            .seek(pos)
+            .map_err(|source| self.error(source, ErrorKind::Seek))
+    }
+}
+
+impl Write for File {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.file
+            .write(buf)
+            .map_err(|source| self.error(source, ErrorKind::Write))
+    }
+
+    fn write_vectored(&mut self, bufs: &[std::io::IoSlice<'_>]) -> std::io::Result<usize> {
+        self.file
+            .write_vectored(bufs)
+            .map_err(|source| self.error(source, ErrorKind::Write))
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.file
+            .flush()
+            .map_err(|source| self.error(source, ErrorKind::Flush))
+    }
+}
+
+impl<'a> Write for &'a File {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        (&(**self).file)
+            .write(buf)
+            .map_err(|source| self.error(source, ErrorKind::Write))
+    }
+
+    fn write_vectored(&mut self, bufs: &[std::io::IoSlice<'_>]) -> std::io::Result<usize> {
+        (&(**self).file)
+            .write_vectored(bufs)
+            .map_err(|source| self.error(source, ErrorKind::Write))
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        (&(**self).file)
+            .flush()
+            .map_err(|source| self.error(source, ErrorKind::Flush))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,224 +1,61 @@
-//! This crate provides the [`File`](struct.File.html) type, a wrapper
-//! around a file handle and its path which wraps all operations with
-//! more helpful error messages.
+/*!
+fs-err is a drop-in replacement for [`std::fs`][std::fs] that provides more
+helpful messages on errors. Extra information includes which operations was
+attmpted and any involved paths.
+
+# Usage
+
+fs-err's API is the same as [`std::fs`], so migrating code to use it is easy.
+
+```no_run
+// use std::fs;
+use fs_err as fs;
+
+let contents = fs::read_to_string("foo.txt")?;
+
+println!("Read foo.txt: {}", contents);
+
+# Ok::<(), std::io::Error>(())
+```
+
+fs-err uses [`std::io::Error`][std::io::Error] for all errors. This helps fs-err
+compose well with traits from the standard library like
+[`std::io::Read`][std::io::Read] and crates that use them like
+[`serde_json`][serde_json]:
+
+```no_run
+use fs_err::File;
+
+let file = File::open("my-config.json")?;
+
+// If an I/O error occurs inside serde_json, the error will include a file path
+// as well as what operation was being performed.
+let decoded: Vec<String> = serde_json::from_reader(file)?;
+
+println!("Program config: {:?}", decoded);
+
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+[std::fs]: https://doc.rust-lang.org/stable/std/fs/
+[std::io::Error]: https://doc.rust-lang.org/stable/std/io/struct.Error.html
+[std::io::Read]: https://doc.rust-lang.org/stable/std/io/trait.Read.html
+[serde_json]: https://crates.io/crates/serde_json
+*/
 
 #![doc(html_root_url = "https://docs.rs/fs-err/2.0.1")]
 #![deny(missing_debug_implementations, missing_docs)]
 
 mod errors;
+mod file;
 
 use std::fs;
-use std::io::{self, Read, Seek, Write};
+use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 
-use errors::{CopyError, Error, ErrorKind};
+use errors::CopyError;
 
-/// A wrapper around a file handle and its path which wraps all
-/// operations with more helpful error messages.
-#[derive(Debug)]
-pub struct File {
-    file: fs::File,
-    path: PathBuf,
-}
-
-impl File {
-    /// Wrapper for [`File::open`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.open).
-    pub fn open<P>(path: P) -> Result<Self, io::Error>
-    where
-        P: AsRef<Path> + Into<PathBuf>,
-    {
-        match fs::File::open(path.as_ref()) {
-            Ok(file) => Ok(File::from_parts(file, path.into())),
-            Err(source) => Err(Error::new(source, ErrorKind::OpenFile, path)),
-        }
-    }
-
-    /// Wrapper for [`File::create`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.create).
-    pub fn create<P>(path: P) -> Result<Self, io::Error>
-    where
-        P: AsRef<Path> + Into<PathBuf>,
-    {
-        match fs::File::create(path.as_ref()) {
-            Ok(file) => Ok(File::from_parts(file, path.into())),
-            Err(source) => Err(Error::new(source, ErrorKind::CreateFile, path)),
-        }
-    }
-
-    /// Wrapper for [`OpenOptions::open`](https://doc.rust-lang.org/stable/std/fs/struct.OpenOptions.html#method.open).
-    pub fn from_options<P>(path: P, options: &fs::OpenOptions) -> Result<Self, io::Error>
-    where
-        P: AsRef<Path> + Into<PathBuf>,
-    {
-        match options.open(path.as_ref()) {
-            Ok(file) => Ok(File::from_parts(file, path.into())),
-            Err(source) => Err(Error::new(source, ErrorKind::OpenFile, path)),
-        }
-    }
-
-    /// Wrapper for [`File::sync_all`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.sync_all).
-    pub fn sync_all(&self) -> Result<(), io::Error> {
-        self.file
-            .sync_all()
-            .map_err(|source| self.error(source, ErrorKind::SyncFile))
-    }
-
-    /// Wrapper for [`File::sync_data`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.sync_data).
-    pub fn sync_data(&self) -> Result<(), io::Error> {
-        self.file
-            .sync_data()
-            .map_err(|source| self.error(source, ErrorKind::SyncFile))
-    }
-
-    /// Wrapper for [`File::set_len`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.set_len).
-    pub fn set_len(&self, size: u64) -> Result<(), io::Error> {
-        self.file
-            .set_len(size)
-            .map_err(|source| self.error(source, ErrorKind::SetLen))
-    }
-
-    /// Wrapper for [`File::metadata`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.metadata).
-    pub fn metadata(&self) -> Result<fs::Metadata, io::Error> {
-        self.file
-            .metadata()
-            .map_err(|source| self.error(source, ErrorKind::Metadata))
-    }
-
-    /// Wrapper for [`File::try_clone`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.try_clone).
-    pub fn try_clone(&self) -> Result<Self, io::Error> {
-        self.file
-            .try_clone()
-            .map(|file| File {
-                file,
-                path: self.path.clone(),
-            })
-            .map_err(|source| self.error(source, ErrorKind::Clone))
-    }
-
-    /// Wrapper for [`File::set_permissions`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.set_permissions).
-    pub fn set_permissions(&self, perm: fs::Permissions) -> Result<(), io::Error> {
-        self.file
-            .set_permissions(perm)
-            .map_err(|source| self.error(source, ErrorKind::SetPermissions))
-    }
-
-    /// Creates a [`File`](struct.File.html) from a raw file and its
-    /// path.
-    pub fn from_parts<P>(file: fs::File, path: P) -> Self
-    where
-        P: Into<PathBuf>,
-    {
-        File {
-            file,
-            path: path.into(),
-        }
-    }
-
-    /// Gets the wrapped file.
-    pub fn file(&self) -> &fs::File {
-        &self.file
-    }
-
-    /// Gets the path of the wrapped file.
-    pub fn path(&self) -> &Path {
-        &self.path
-    }
-
-    /// Wrap the error in information specific to this `File` object.
-    fn error(&self, source: io::Error, kind: ErrorKind) -> io::Error {
-        Error::new(source, kind, &self.path)
-    }
-}
-
-impl Read for File {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        self.file
-            .read(buf)
-            .map_err(|source| self.error(source, ErrorKind::Read))
-    }
-
-    fn read_vectored(&mut self, bufs: &mut [std::io::IoSliceMut<'_>]) -> std::io::Result<usize> {
-        self.file
-            .read_vectored(bufs)
-            .map_err(|source| self.error(source, ErrorKind::Read))
-    }
-}
-
-impl<'a> Read for &'a File {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        (&(**self).file)
-            .read(buf)
-            .map_err(|source| self.error(source, ErrorKind::Read))
-    }
-
-    fn read_vectored(&mut self, bufs: &mut [std::io::IoSliceMut<'_>]) -> std::io::Result<usize> {
-        (&(**self).file)
-            .read_vectored(bufs)
-            .map_err(|source| self.error(source, ErrorKind::Read))
-    }
-}
-
-impl Seek for File {
-    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
-        self.file
-            .seek(pos)
-            .map_err(|source| self.error(source, ErrorKind::Seek))
-    }
-}
-
-impl<'a> Seek for &'a File {
-    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
-        (&(**self).file)
-            .seek(pos)
-            .map_err(|source| self.error(source, ErrorKind::Seek))
-    }
-}
-
-impl Write for File {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.file
-            .write(buf)
-            .map_err(|source| self.error(source, ErrorKind::Write))
-    }
-
-    fn write_vectored(&mut self, bufs: &[std::io::IoSlice<'_>]) -> std::io::Result<usize> {
-        self.file
-            .write_vectored(bufs)
-            .map_err(|source| self.error(source, ErrorKind::Write))
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.file
-            .flush()
-            .map_err(|source| self.error(source, ErrorKind::Flush))
-    }
-}
-
-impl<'a> Write for &'a File {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        (&(**self).file)
-            .write(buf)
-            .map_err(|source| self.error(source, ErrorKind::Write))
-    }
-
-    fn write_vectored(&mut self, bufs: &[std::io::IoSlice<'_>]) -> std::io::Result<usize> {
-        (&(**self).file)
-            .write_vectored(bufs)
-            .map_err(|source| self.error(source, ErrorKind::Write))
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        (&(**self).file)
-            .flush()
-            .map_err(|source| self.error(source, ErrorKind::Flush))
-    }
-}
-
-fn initial_buffer_size(file: &File) -> usize {
-    file.file()
-        .metadata()
-        .map(|m| m.len() as usize + 1)
-        .unwrap_or(0)
-}
+pub use file::*;
 
 /// Wrapper for [`fs::read`](https://doc.rust-lang.org/stable/std/fs/fn.read.html).
 pub fn read<P: AsRef<Path> + Into<PathBuf>>(path: P) -> io::Result<Vec<u8>> {
@@ -251,4 +88,11 @@ where
     Q: AsRef<Path> + Into<PathBuf>,
 {
     fs::copy(from.as_ref(), to.as_ref()).map_err(|source| CopyError::new(source, from, to))
+}
+
+fn initial_buffer_size(file: &File) -> usize {
+    file.file()
+        .metadata()
+        .map(|m| m.len() as usize + 1)
+        .unwrap_or(0)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,32 @@ fs-err is a drop-in replacement for [`std::fs`][std::fs] that provides more
 helpful messages on errors. Extra information includes which operations was
 attmpted and any involved paths.
 
+# Error Messages
+
+Using [`std::fs`][std::fs], if this code fails:
+
+```no_run
+# use std::fs::File;
+let file = File::open("does not exist.txt")?;
+# Ok::<(), std::io::Error>(())
+```
+
+The error message that Rust gives you isn't very useful:
+
+```txt
+The system cannot find the file specified. (os error 2)
+```
+
+...but if we use fs-err instead, our error contains more actionable information:
+
+```txt
+failed to open file `does not exist.txt`
+    caused by: The system cannot find the file specified. (os error 2)
+```
+
 # Usage
 
-fs-err's API is the same as [`std::fs`], so migrating code to use it is easy.
+fs-err's API is the same as [`std::fs`][std::fs], so migrating code to use it is easy.
 
 ```no_run
 // use std::fs;


### PR DESCRIPTION
Closes #6.

This PR is still early, but I'm opening it now so you can take a look before I get too far in.

I thought this would be a good application of [cargo-readme](https://github.com/livioribeiro/cargo-readme) and so the source of truth for `README.md` is contained in `src/lib.rs`. I also took the time to move the `File` struct into its own file because `lib.rs` was getting bigger. This helps prepare for #4, too.

There are no functionality changes in this PR, just documentation ones.

## TODO
- [x] Error message comparison section
