### PR TITLE
Implement fs_err::metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # fs-err Changelog
 
+## Unreleased Changes
+* Added `metadata`. ([#15](https://github.com/andrewhickman/fs-err/pull/15))
+
 ## 2.1.0
 * Updated crate-level documentation. ([#8](https://github.com/andrewhickman/fs-err/pull/8))
 * Added `read_dir`, `ReadDir`, and `DirEntry`. ([#9](https://github.com/andrewhickman/fs-err/pull/9))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ use std::fs;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 
-use errors::CopyError;
+use errors::{CopyError, Error, ErrorKind};
 
 pub use dir::*;
 pub use file::*;
@@ -113,6 +113,11 @@ where
     Q: AsRef<Path> + Into<PathBuf>,
 {
     fs::copy(from.as_ref(), to.as_ref()).map_err(|source| CopyError::new(source, from, to))
+}
+
+/// Wrapper for [`fs::metadata`](https://doc.rust-lang.org/stable/std/fs/fn.metadata.html).
+pub fn metadata<P: AsRef<Path> + Into<PathBuf>>(path: P) -> io::Result<fs::Metadata> {
+    fs::metadata(path.as_ref()).map_err(|source| Error::new(source, ErrorKind::Metadata, path))
 }
 
 fn initial_buffer_size(file: &File) -> usize {


### PR DESCRIPTION
Closes #13.

Another very small PR. This should finish up most of the reading APIs that I need to adopt fs-err in a lot of my projects!

I can submit larger PRs if you'd prefer. Most of these small PRs to reach coverage are going to be pretty mechanical and easy to review I imagine.