### PR TITLE
Add Windows to build matrix and turn off fast fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,13 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
-
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         rust_version: [stable, "1.39.0"]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Now that we have Windows-specific code, it would be a good idea to run fs-err's CI pipeline on Windows in addition to Linux.

Because of the changes in https://github.com/andrewhickman/fs-err/commit/f61ae29f9e8962f8d4f1d51fcd6262cecc0e4e44, I believe this CI will currently fail on Windows.