### PR TITLE
Implement create_dir and create_dir_all

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 pub(crate) enum ErrorKind {
     OpenFile,
     CreateFile,
+    CreateDir,
     SyncFile,
     SetLen,
     Metadata,
@@ -54,6 +55,7 @@ impl fmt::Display for Error {
         match self.kind {
             OpenFile => write!(formatter, "failed to open file `{}`", path),
             CreateFile => write!(formatter, "failed to create file `{}`", path),
+            CreateDir => write!(formatter, "failed to create directory `{}`", path),
             SyncFile => write!(formatter, "failed to sync file `{}`", path),
             SetLen => write!(formatter, "failed to set length of file `{}`", path),
             Metadata => write!(formatter, "failed to query metadata of file `{}`", path),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,23 @@ where
     fs::copy(from.as_ref(), to.as_ref()).map_err(|source| CopyError::new(source, from, to))
 }
 
+/// Wrapper for [`fs::create_dir`](https://doc.rust-lang.org/stable/std/fs/fn.create_dir.html).
+pub fn create_dir<P>(path: P) -> io::Result<()>
+where
+    P: AsRef<Path> + Into<PathBuf>,
+{
+    fs::create_dir(path.as_ref()).map_err(|source| Error::new(source, ErrorKind::CreateDir, path))
+}
+
+/// Wrapper for [`fs::create_dir_all`](https://doc.rust-lang.org/stable/std/fs/fn.create_dir_all.html).
+pub fn create_dir_all<P>(path: P) -> io::Result<()>
+where
+    P: AsRef<Path> + Into<PathBuf>,
+{
+    fs::create_dir_all(path.as_ref())
+        .map_err(|source| Error::new(source, ErrorKind::CreateDir, path))
+}
+
 /// Wrapper for [`fs::remove_dir`](https://doc.rust-lang.org/stable/std/fs/fn.remove_dir.html).
 pub fn remove_dir<P>(path: P) -> io::Result<()>
 where


### PR DESCRIPTION
Closes #10.

Similar to #16, we'll want to come back to this in the future and flesh out the implementation to get better errors. I think it's useful to get to as close to feature parity with `std::fs`, though!