### PR TITLE
Publish the crates on new git tag automatically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,18 @@ jobs:
         cargo fmt -- --check
         cargo clippy
       if: matrix.rust_version == 'stable'
+
+  publish:
+    # Publishing goes when we create a new git tag on the repo
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    # XXX: this job must execute only if all checks pass!
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+      - run: cargo publish --token ${{ secrets.CRATES_TOKEN }})


### PR DESCRIPTION
Just add `CRATES_TOKEN` (crates.io api token) to the repo secrets and run:
```
git tag <bruh>
git push --tags
```

This will also make the publishing more transparent to the users. It will give additional guarantees that the crate is published with it's code unmodified (without some malicious code).