### PR TITLE
Add aliases to std::path::Path via extension trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ println!("Program config: {:?}", decoded);
 mod dir;
 mod errors;
 mod file;
+mod path;
 
 use std::fs;
 use std::io::{self, Read, Write};
@@ -81,6 +82,7 @@ use errors::{Error, ErrorKind, SourceDestError, SourceDestErrorKind};
 
 pub use dir::*;
 pub use file::*;
+pub use path::PathExt;
 
 /// Wrapper for [`fs::read`](https://doc.rust-lang.org/stable/std/fs/fn.read.html).
 pub fn read<P: AsRef<Path> + Into<PathBuf>>(path: P) -> io::Result<Vec<u8>> {

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,0 +1,49 @@
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Defines aliases on [`Path`](https://doc.rust-lang.org/std/path/struct.Path.html) for `fs_err` functions.
+///
+/// This trait is sealed and can not be implemented by other crates.
+//
+// Because noone else can implement it, we can add methods backwards-compatibly.
+pub trait PathExt: private::Sealed {
+    /// Wrapper for [`crate::metadata`].
+    fn fs_err_metadata(&self) -> io::Result<fs::Metadata>;
+    /// Wrapper for [`crate::symlink_metadata`].
+    fn fs_err_symlink_metadata(&self) -> io::Result<fs::Metadata>;
+    /// Wrapper for [`crate::canonicalize`].
+    fn fs_err_canonicalize(&self) -> io::Result<PathBuf>;
+    /// Wrapper for [`crate::read_link`].
+    fn fs_err_read_link(&self) -> io::Result<PathBuf>;
+    /// Wrapper for [`crate::read_dir`].
+    fn fs_err_read_dir(&self) -> io::Result<crate::ReadDir>;
+}
+
+impl PathExt for Path {
+    fn fs_err_metadata(&self) -> io::Result<fs::Metadata> {
+        crate::metadata(self)
+    }
+
+    fn fs_err_symlink_metadata(&self) -> io::Result<fs::Metadata> {
+        crate::symlink_metadata(self)
+    }
+
+    fn fs_err_canonicalize(&self) -> io::Result<PathBuf> {
+        crate::canonicalize(self)
+    }
+
+    fn fs_err_read_link(&self) -> io::Result<PathBuf> {
+        crate::read_link(self)
+    }
+
+    fn fs_err_read_dir(&self) -> io::Result<crate::ReadDir> {
+        crate::read_dir(self)
+    }
+}
+
+mod private {
+    pub trait Sealed {}
+
+    impl Sealed for std::path::Path {}
+}


### PR DESCRIPTION
This PR is based on #25.

`Path` has some nice methods which are just shortcuts for free functions in `std::fs`. `path.some_fn()` => `std::fs::some_fn(path)`. Having to translate such calls to free function calls to benefit from this crate is bothersome.

This PR adds aliases that work the same way except they call `fs_err::some_fn`. Because inherent methods take precedence over trait methods, they must have different names. I have simply appended `_err` to all method names.

I invite bike shedding on the method names and the entire approach.

Defining an extension trait is easier than creating a wrapper struct (unless you're abusing `Deref`), but also more error prone for the user as they have to make sure to call the right method manually.