### PR TITLE
add set_permissions()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,6 +210,15 @@ pub fn symlink_metadata<P: AsRef<Path> + Into<PathBuf>>(path: P) -> io::Result<f
         .map_err(|source| Error::new(source, ErrorKind::SymlinkMetadata, path))
 }
 
+/// Wrapper for [`fs::set_permissions`](https://doc.rust-lang.org/stable/std/fs/fn.set_permissions.html).
+pub fn set_permissions<P: AsRef<Path> + Into<PathBuf>>(
+    path: P,
+    perm: fs::Permissions,
+) -> io::Result<()> {
+    fs::set_permissions(path.as_ref(), perm)
+        .map_err(|source| Error::new(source, ErrorKind::SetPermissions, path))
+}
+
 fn initial_buffer_size(file: &File) -> usize {
     file.file()
         .metadata()


### PR DESCRIPTION
As I mentioned in #25, I initially left this out because I wasn't sure how to include the permissions in the error message, but I noticed that `File::set_permissions` already exists and also just doesn't mention the exact permissions in the message.

This does the same. With this, all free functions in `std::fs` have wrappers.