### PR TITLE
Add os specific APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # fs-err Changelog
 
+## Unreleased
+* Added `symlink` for unix platforms
+* Added `symlink_file` and `symlink_dir` for windows
+* Implemented os-specific extension traits for `File`
+  - `std::os::unix::io::{AsRawFd, IntoRawFd}`
+  - `std::os::windows::io::{AsRawHandle, IntoRawHandle}`
+  - Added trait wrappers for `std::os::{unix, windows}::fs::FileExt` and implemented them for `fs_err::File`
+* Implemented os-specific extension traits for `OpenOptions`
+  - Added trait wrappers for `std::os::{unix, windows}::fs::OpenOptionsExt` and implemented them for `fs_err::OpenOptions`
+  
 ## 2.4.0
 * Added `canonicalize`, `hard link`, `read_link`, `rename`, `symlink_metadata` and `soft_link`. ([#25](https://github.com/andrewhickman/fs-err/pull/25))
 * Added aliases to `std::path::Path` via extension trait ([#26](https://github.com/andrewhickman/fs-err/pull/26))

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,6 +23,16 @@ pub(crate) enum ErrorKind {
     Canonicalize,
     ReadLink,
     SymlinkMetadata,
+
+    #[cfg(windows)]
+    SeekRead,
+    #[cfg(windows)]
+    SeekWrite,
+
+    #[cfg(unix)]
+    ReadAt,
+    #[cfg(unix)]
+    WriteAt,
 }
 
 /// Contains an IO error that has a file path attached.
@@ -74,6 +84,16 @@ impl fmt::Display for Error {
             Canonicalize => write!(formatter, "failed to canonicalize path `{}`", path),
             ReadLink => write!(formatter, "failed to read symbolic link `{}`", path),
             SymlinkMetadata => write!(formatter, "failed to query metadata of symlink `{}`", path),
+
+            #[cfg(windows)]
+            SeekRead => write!(formatter, "failed to seek and read from `{}`", path),
+            #[cfg(windows)]
+            SeekWrite => write!(formatter, "failed to seek and write to `{}`", path),
+
+            #[cfg(unix)]
+            ReadAt => write!(formatter, "failed to read with offset from `{}`", path),
+            #[cfg(unix)]
+            WriteAt => write!(formatter, "failed to write with offset to `{}`", path),
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -94,6 +94,14 @@ pub(crate) enum SourceDestErrorKind {
     HardLink,
     Rename,
     SoftLink,
+
+    #[cfg(unix)]
+    Symlink,
+
+    #[cfg(windows)]
+    SymlinkDir,
+    #[cfg(windows)]
+    SymlinkFile,
 }
 
 /// Error type used by functions like `fs::copy` that holds two paths.
@@ -140,6 +148,20 @@ impl fmt::Display for SourceDestError {
             }
             SourceDestErrorKind::SoftLink => {
                 write!(formatter, "failed to softlink file from {} to {}", from, to)
+            }
+
+            #[cfg(unix)]
+            SourceDestErrorKind::Symlink => {
+                write!(formatter, "failed to symlink file from {} to {}", from, to)
+            }
+
+            #[cfg(windows)]
+            SourceDestErrorKind::SymlinkFile => {
+                write!(formatter, "failed to symlink file from {} to {}", from, to)
+            }
+            #[cfg(windows)]
+            SourceDestErrorKind::SymlinkDir => {
+                write!(formatter, "failed to symlink dir from {} to {}", from, to)
             }
         }
     }

--- a/src/file.rs
+++ b/src/file.rs
@@ -43,7 +43,7 @@ impl File {
     /// Wrapper for [`OpenOptions::open`](https://doc.rust-lang.org/stable/std/fs/struct.OpenOptions.html#method.open).
     ///
     /// This takes [`&std::fs::OpenOptions`](https://doc.rust-lang.org/stable/std/fs/struct.OpenOptions.html),
-    /// not [`fs_err::OpenOptions`].
+    /// not [`crate::OpenOptions`].
     #[deprecated = "use fs_err::OpenOptions::open instead"]
     pub fn from_options<P>(path: P, options: &fs::OpenOptions) -> Result<Self, io::Error>
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,3 +230,11 @@ fn initial_buffer_size(file: &File) -> usize {
         .map(|m| m.len() as usize + 1)
         .unwrap_or(0)
 }
+
+pub(crate) use private::Sealed;
+mod private {
+    pub trait Sealed {}
+
+    impl Sealed for crate::File {}
+    impl Sealed for std::path::Path {}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,4 +237,5 @@ mod private {
 
     impl Sealed for crate::File {}
     impl Sealed for std::path::Path {}
+    impl Sealed for crate::OpenOptions {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ mod dir;
 mod errors;
 mod file;
 mod open_options;
+pub mod os;
 mod path;
 
 use std::fs;

--- a/src/open_options.rs
+++ b/src/open_options.rs
@@ -83,3 +83,52 @@ impl OpenOptions {
         &mut self.0
     }
 }
+
+#[cfg(unix)]
+mod unix {
+    use crate::os::unix::fs::OpenOptionsExt;
+    use std::os::unix::fs::OpenOptionsExt as _;
+    impl OpenOptionsExt for crate::OpenOptions {
+        fn mode(&mut self, mode: u32) -> &mut Self {
+            self.options_mut().mode(mode);
+            self
+        }
+
+        fn custom_flags(&mut self, flags: i32) -> &mut Self {
+            self.options_mut().custom_flags(flags);
+            self
+        }
+    }
+}
+
+#[cfg(windows)]
+mod windows {
+    use crate::os::windows::fs::OpenOptionsExt;
+    use std::os::windows::fs::OpenOptionsExt as _;
+
+    impl OpenOptionsExt for crate::OpenOptions {
+        fn access_mode(&mut self, access: u32) -> &mut Self {
+            self.options_mut().access_mode(access);
+            self
+        }
+
+        fn share_mode(&mut self, val: u32) -> &mut Self {
+            self.options_mut().share_mode(val);
+            self
+        }
+        fn custom_flags(&mut self, flags: u32) -> &mut Self {
+            self.options_mut().custom_flags(flags);
+            self
+        }
+
+        fn attributes(&mut self, val: u32) -> &mut Self {
+            self.options_mut().attributes(val);
+            self
+        }
+
+        fn security_qos_flags(&mut self, flags: u32) -> &mut Self {
+            self.options_mut().security_qos_flags(flags);
+            self
+        }
+    }
+}

--- a/src/os.rs
+++ b/src/os.rs
@@ -1,0 +1,11 @@
+//! OS-specific functionality.
+
+// The std-library has a couple more platforms than just `unix` for which these apis
+// are defined, but we're using just `unix` here. We can always expand later.
+#[cfg(unix)]
+/// Platform-specific extensions for Unix platforms.
+pub mod unix;
+
+#[cfg(windows)]
+/// Platform-specific extensions for Windows.
+pub mod windows;

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -14,4 +14,15 @@ pub mod fs {
         std::os::unix::fs::symlink(src.as_ref(), dst.as_ref())
             .map_err(|err| SourceDestError::new(err, SourceDestErrorKind::Symlink, src, dst))
     }
+
+    /// Wrapper for [`std::os::unix::fs::FileExt`](https://doc.rust-lang.org/std/os/unix/fs/trait.FileExt.html).
+    ///
+    /// The std traits might be extended in the future (See issue [#49961](https://github.com/rust-lang/rust/issues/49961#issuecomment-382751777)).
+    /// This trait is sealed and can not be implemented by other crates.
+    pub trait FileExt: crate::Sealed {
+        /// Wrapper for [`FileExt::read_at`](https://doc.rust-lang.org/std/os/unix/fs/trait.FileExt.html#tymethod.read_at)
+        fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize>;
+        /// Wrapper for [`FileExt::write_at`](https://doc.rust-lang.org/std/os/unix/fs/trait.FileExt.html#tymethod.write_at)
+        fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize>;
+    }
 }

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -1,0 +1,17 @@
+/// Unix-specific extensions to wrappers in `fs_err` for `std::fs` types.
+pub mod fs {
+    use std::path::Path;
+    use std::{io, path::PathBuf};
+
+    use crate::SourceDestError;
+    use crate::SourceDestErrorKind;
+
+    /// Wrapper for [`std::os::unix::fs::symlink`](https://doc.rust-lang.org/std/os/unix/fs/fn.symlink.html)
+    pub fn symlink<P: AsRef<Path> + Into<PathBuf>, Q: AsRef<Path> + Into<PathBuf>>(
+        src: P,
+        dst: Q,
+    ) -> io::Result<()> {
+        std::os::unix::fs::symlink(src.as_ref(), dst.as_ref())
+            .map_err(|err| SourceDestError::new(err, SourceDestErrorKind::Symlink, src, dst))
+    }
+}

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -25,4 +25,15 @@ pub mod fs {
         /// Wrapper for [`FileExt::write_at`](https://doc.rust-lang.org/std/os/unix/fs/trait.FileExt.html#tymethod.write_at)
         fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize>;
     }
+
+    /// Wrapper for [`std::os::unix::fs::OpenOptionsExt`](https://doc.rust-lang.org/std/os/unix/fs/trait.OpenOptionsExt.html)
+    ///
+    /// The std traits might be extended in the future (See issue [#49961](https://github.com/rust-lang/rust/issues/49961#issuecomment-382751777)).
+    /// This trait is sealed and can not be implemented by other crates.
+    pub trait OpenOptionsExt: crate::Sealed {
+        /// Wapper for [`OpenOptionsExt::mode`](https://doc.rust-lang.org/std/os/unix/fs/trait.OpenOptionsExt.html#tymethod.mode)
+        fn mode(&mut self, mode: u32) -> &mut Self;
+        /// Wapper for [`OpenOptionsExt::custom_flags`](https://doc.rust-lang.org/std/os/unix/fs/trait.OpenOptionsExt.html#tymethod.custom_flags)
+        fn custom_flags(&mut self, flags: i32) -> &mut Self;
+    }
 }

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -1,0 +1,23 @@
+/// Windows-specific extensions to wrappers in `fs_err` for `std::fs` types.
+pub mod fs {
+    use crate::{SourceDestError, SourceDestErrorKind};
+    use std::io;
+    use std::path::{Path, PathBuf};
+    /// Wrapper for [std::os::windows::fs::symlink_dir](https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_dir.html)
+    pub fn symlink_dir<P: AsRef<Path> + Into<PathBuf>, Q: AsRef<Path> + Into<PathBuf>>(
+        src: P,
+        dst: Q,
+    ) -> io::Result<()> {
+        std::os::windows::fs::symlink_dir(src.as_ref(), dst.as_ref())
+            .map_err(|err| SourceDestError::new(err, SourceDestErrorKind::SymlinkDir, src, dst))
+    }
+
+    /// Wrapper for [std::os::windows::fs::symlink_file](https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_file.html)
+    pub fn symlink_file<P: AsRef<Path> + Into<PathBuf>, Q: AsRef<Path> + Into<PathBuf>>(
+        src: P,
+        dst: Q,
+    ) -> io::Result<()> {
+        std::os::windows::fs::symlink_file(src.as_ref(), dst.as_ref())
+            .map_err(|err| SourceDestError::new(err, SourceDestErrorKind::SymlinkFile, src, dst))
+    }
+}

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -20,4 +20,15 @@ pub mod fs {
         std::os::windows::fs::symlink_file(src.as_ref(), dst.as_ref())
             .map_err(|err| SourceDestError::new(err, SourceDestErrorKind::SymlinkFile, src, dst))
     }
+
+    /// Wrapper for [`std::os::windows::fs::FileExt`](https://doc.rust-lang.org/std/os/windows/fs/trait.FileExt.html).
+    ///
+    /// The std traits might be extended in the future (See issue [#49961](https://github.com/rust-lang/rust/issues/49961#issuecomment-382751777)).
+    /// This trait is sealed and can not be implemented by other crates.
+    pub trait FileExt: crate::Sealed {
+        /// Wrapper for [`FileExt::seek_read`](https://doc.rust-lang.org/std/os/windows/fs/trait.FileExt.html#tymethod.seek_read)
+        fn seek_read(&self, buf: &mut [u8], offset: u64) -> io::Result<usize>;
+        /// Wrapper for [`FileExt::seek_wriite`](https://doc.rust-lang.org/std/os/windows/fs/trait.FileExt.html#tymethod.seek_write)
+        fn seek_write(&self, buf: &[u8], offset: u64) -> io::Result<usize>;
+    }
 }

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -31,4 +31,21 @@ pub mod fs {
         /// Wrapper for [`FileExt::seek_wriite`](https://doc.rust-lang.org/std/os/windows/fs/trait.FileExt.html#tymethod.seek_write)
         fn seek_write(&self, buf: &[u8], offset: u64) -> io::Result<usize>;
     }
+
+    /// Wrapper for [`std::os::windows::fs::OpenOptionsExt`](https://doc.rust-lang.org/std/os/windows/fs/trait.OpenOptionsExt.html)
+    ///
+    /// The std traits might be extended in the future (See issue [#49961](https://github.com/rust-lang/rust/issues/49961#issuecomment-382751777)).
+    /// This trait is sealed and can not be implemented by other crates.
+    pub trait OpenOptionsExt: crate::Sealed {
+        /// Wrapper for [`OpenOptionsExt::access_mode`](https://doc.rust-lang.org/std/os/windows/fs/trait.OpenOptionsExt.html#tymethod.access_mode)
+        fn access_mode(&mut self, access: u32) -> &mut Self;
+        /// Wrapper for [`OpenOptionsExt::share_mode`](https://doc.rust-lang.org/std/os/windows/fs/trait.OpenOptionsExt.html#tymethod.share_mode)
+        fn share_mode(&mut self, val: u32) -> &mut Self;
+        /// Wrapper for [`OpenOptionsExt::custom_flags`](https://doc.rust-lang.org/std/os/windows/fs/trait.OpenOptionsExt.html#tymethod.custom_flags)
+        fn custom_flags(&mut self, flags: u32) -> &mut Self;
+        /// Wrapper for [`OpenOptionsExt::attributes`](https://doc.rust-lang.org/std/os/windows/fs/trait.OpenOptionsExt.html#tymethod.attributes)
+        fn attributes(&mut self, val: u32) -> &mut Self;
+        /// Wrapper for [`OpenOptionsExt::security_qos_flags`](https://doc.rust-lang.org/std/os/windows/fs/trait.OpenOptionsExt.html#tymethod.security_qos_flags)
+        fn security_qos_flags(&mut self, flags: u32) -> &mut Self;
+    }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 /// This trait is sealed and can not be implemented by other crates.
 //
 // Because noone else can implement it, we can add methods backwards-compatibly.
-pub trait PathExt: private::Sealed {
+pub trait PathExt: crate::Sealed {
     /// Wrapper for [`crate::metadata`].
     fn fs_err_metadata(&self) -> io::Result<fs::Metadata>;
     /// Wrapper for [`crate::symlink_metadata`].
@@ -40,10 +40,4 @@ impl PathExt for Path {
     fn fs_err_read_dir(&self) -> io::Result<crate::ReadDir> {
         crate::read_dir(self)
     }
-}
-
-mod private {
-    pub trait Sealed {}
-
-    impl Sealed for std::path::Path {}
 }


### PR DESCRIPTION
* Added `symlink` for unix platforms
* Added `symlink_file` and `symlink_dir` for windows
* Implemented os-specific extension traits for `File`
  - `std::os::unix::io::{AsRawFd, IntoRawFd}`
  - `std::os::windows::io::{AsRawHandle, IntoRawHandle}`
  - Added trait wrappers for `std::os::{unix, windows}::fs::FileExt` and implemented them for `fs_err::File`
* Implemented os-specific extension traits for `OpenOptions`
  - Added trait wrappers for `std::os::{unix, windows}::fs::OpenOptionsExt` and implemented them for `fs_err::OpenOptions`
 
I believe I have implemented all the os-specific extension traits of the three major platforms (unix, linux, windws) for which wrappers are already defined. The rest will need to be added after the missing wrappers are added (cf #29).

(Thank god trait methods inherit documentation and most new methods are infallible. The boilerplate would have killed me otherwise)