### PR TITLE
Convert generic types early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   - Added trait wrappers for `std::os::{unix, windows}::fs::FileExt` and implemented them for `fs_err::File`
 * Implemented os-specific extension traits for `OpenOptions`
   - Added trait wrappers for `std::os::{unix, windows}::fs::OpenOptionsExt` and implemented them for `fs_err::OpenOptions`
+* Improved compile times by converting arguments early and forwarding only a small number of types internally. There will be a slight performance hit only in the error case.
+* Reduced trait bounds on generics from `AsRef<Path> + Into<PathBuf>` to either `AsRef<Path>` or `Into<PathBuf>`, making the functions more general.
   
 ## 2.4.0
 * Added `canonicalize`, `hard link`, `read_link`, `rename`, `symlink_metadata` and `soft_link`. ([#25](https://github.com/andrewhickman/fs-err/pull/25))

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,7 @@
 use std::error::Error as StdError;
 use std::fmt;
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum ErrorKind {
@@ -47,19 +47,12 @@ pub(crate) struct Error {
 }
 
 impl Error {
-    pub fn new(source: io::Error, kind: ErrorKind, path: PathBuf) -> io::Error {
-        io::Error::new(source.kind(), Self { kind, source, path })
+    pub fn new(source: io::Error, kind: ErrorKind, path: impl Into<PathBuf>) -> io::Error {
+        Self::_new(source, kind, path.into())
     }
 
-    pub fn new_from_ref(source: io::Error, kind: ErrorKind, path: &Path) -> io::Error {
-        io::Error::new(
-            source.kind(),
-            Self {
-                kind,
-                source,
-                path: path.to_path_buf(),
-            },
-        )
+    fn _new(source: io::Error, kind: ErrorKind, path: PathBuf) -> io::Error {
+        io::Error::new(source.kind(), Self { kind, source, path })
     }
 }
 
@@ -141,27 +134,27 @@ impl SourceDestError {
     pub fn new(
         source: io::Error,
         kind: SourceDestErrorKind,
+        from_path: impl Into<PathBuf>,
+        to_path: impl Into<PathBuf>,
+    ) -> io::Error {
+        Self::_new(source, kind, from_path.into(), to_path.into())
+    }
+
+    fn _new(
+        source: io::Error,
+        kind: SourceDestErrorKind,
         from_path: PathBuf,
         to_path: PathBuf,
     ) -> io::Error {
         io::Error::new(
             source.kind(),
             Self {
-                source,
                 kind,
+                source,
                 from_path,
                 to_path,
             },
         )
-    }
-
-    pub fn new_from_ref(
-        source: io::Error,
-        kind: SourceDestErrorKind,
-        from_path: &Path,
-        to_path: &Path,
-    ) -> io::Error {
-        Self::new(source, kind, from_path.to_path_buf(), to_path.to_path_buf())
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,7 @@
 use std::error::Error as StdError;
 use std::fmt;
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum ErrorKind {
@@ -47,13 +47,17 @@ pub(crate) struct Error {
 }
 
 impl Error {
-    pub fn new<P: Into<PathBuf>>(source: io::Error, kind: ErrorKind, path: P) -> io::Error {
+    pub fn new(source: io::Error, kind: ErrorKind, path: PathBuf) -> io::Error {
+        io::Error::new(source.kind(), Self { kind, source, path })
+    }
+
+    pub fn new_from_ref(source: io::Error, kind: ErrorKind, path: &Path) -> io::Error {
         io::Error::new(
             source.kind(),
             Self {
                 kind,
                 source,
-                path: path.into(),
+                path: path.to_path_buf(),
             },
         )
     }
@@ -134,21 +138,30 @@ pub(crate) struct SourceDestError {
 }
 
 impl SourceDestError {
-    pub fn new<P: Into<PathBuf>, Q: Into<PathBuf>>(
+    pub fn new(
         source: io::Error,
         kind: SourceDestErrorKind,
-        from: P,
-        to: Q,
+        from_path: PathBuf,
+        to_path: PathBuf,
     ) -> io::Error {
         io::Error::new(
             source.kind(),
             Self {
                 source,
                 kind,
-                from_path: from.into(),
-                to_path: to.into(),
+                from_path,
+                to_path,
             },
         )
+    }
+
+    pub fn new_from_ref(
+        source: io::Error,
+        kind: SourceDestErrorKind,
+        from_path: &Path,
+        to_path: &Path,
+    ) -> io::Error {
+        Self::new(source, kind, from_path.to_path_buf(), to_path.to_path_buf())
     }
 }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -21,10 +21,11 @@ impl File {
     /// Wrapper for [`File::open`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.open).
     pub fn open<P>(path: P) -> Result<Self, io::Error>
     where
-        P: AsRef<Path> + Into<PathBuf>,
+        P: Into<PathBuf>,
     {
-        match fs::File::open(path.as_ref()) {
-            Ok(file) => Ok(File::from_parts(file, path.into())),
+        let path = path.into();
+        match fs::File::open(&path) {
+            Ok(file) => Ok(File::from_parts(file, path)),
             Err(source) => Err(Error::new(source, ErrorKind::OpenFile, path)),
         }
     }
@@ -32,10 +33,11 @@ impl File {
     /// Wrapper for [`File::create`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.create).
     pub fn create<P>(path: P) -> Result<Self, io::Error>
     where
-        P: AsRef<Path> + Into<PathBuf>,
+        P: Into<PathBuf>,
     {
-        match fs::File::create(path.as_ref()) {
-            Ok(file) => Ok(File::from_parts(file, path.into())),
+        let path = path.into();
+        match fs::File::create(&path) {
+            Ok(file) => Ok(File::from_parts(file, path)),
             Err(source) => Err(Error::new(source, ErrorKind::CreateFile, path)),
         }
     }
@@ -47,10 +49,11 @@ impl File {
     #[deprecated = "use fs_err::OpenOptions::open instead"]
     pub fn from_options<P>(path: P, options: &fs::OpenOptions) -> Result<Self, io::Error>
     where
-        P: AsRef<Path> + Into<PathBuf>,
+        P: Into<PathBuf>,
     {
-        match options.open(path.as_ref()) {
-            Ok(file) => Ok(File::from_parts(file, path.into())),
+        let path = path.into();
+        match options.open(&path) {
+            Ok(file) => Ok(File::from_parts(file, path)),
             Err(source) => Err(Error::new(source, ErrorKind::OpenFile, path)),
         }
     }
@@ -132,7 +135,7 @@ impl File {
 
     /// Wrap the error in information specific to this `File` object.
     fn error(&self, source: io::Error, kind: ErrorKind) -> io::Error {
-        Error::new(source, kind, &self.path)
+        Error::new_from_ref(source, kind, &self.path)
     }
 }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -146,7 +146,7 @@ impl File {
 
     /// Wrap the error in information specific to this `File` object.
     fn error(&self, source: io::Error, kind: ErrorKind) -> io::Error {
-        Error::new_from_ref(source, kind, &self.path)
+        Error::new(source, kind, &self.path)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ pub fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
     let mut file = file::open(path.as_ref()).map_err(|err_gen| err_gen(path.to_path_buf()))?;
     let mut bytes = Vec::with_capacity(initial_buffer_size(&file));
     file.read_to_end(&mut bytes)
-        .map_err(|err| Error::new_from_ref(err, ErrorKind::Read, path))?;
+        .map_err(|err| Error::new(err, ErrorKind::Read, path))?;
     Ok(bytes)
 }
 
@@ -103,7 +103,7 @@ pub fn read_to_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
     let mut file = file::open(path.as_ref()).map_err(|err_gen| err_gen(path.to_path_buf()))?;
     let mut string = String::with_capacity(initial_buffer_size(&file));
     file.read_to_string(&mut string)
-        .map_err(|err| Error::new_from_ref(err, ErrorKind::Read, path))?;
+        .map_err(|err| Error::new(err, ErrorKind::Read, path))?;
     Ok(string)
 }
 
@@ -113,7 +113,7 @@ pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result
     file::create(path)
         .map_err(|err_gen| err_gen(path.to_path_buf()))?
         .write_all(contents.as_ref())
-        .map_err(|err| Error::new_from_ref(err, ErrorKind::Write, path))
+        .map_err(|err| Error::new(err, ErrorKind::Write, path))
 }
 
 /// Wrapper for [`fs::copy`](https://doc.rust-lang.org/stable/std/fs/fn.copy.html).
@@ -124,9 +124,8 @@ where
 {
     let from = from.as_ref();
     let to = to.as_ref();
-    fs::copy(from, to).map_err(|source| {
-        SourceDestError::new_from_ref(source, SourceDestErrorKind::Copy, from, to)
-    })
+    fs::copy(from, to)
+        .map_err(|source| SourceDestError::new(source, SourceDestErrorKind::Copy, from, to))
 }
 
 /// Wrapper for [`fs::create_dir`](https://doc.rust-lang.org/stable/std/fs/fn.create_dir.html).
@@ -135,7 +134,7 @@ where
     P: AsRef<Path>,
 {
     let path = path.as_ref();
-    fs::create_dir(path).map_err(|source| Error::new_from_ref(source, ErrorKind::CreateDir, path))
+    fs::create_dir(path).map_err(|source| Error::new(source, ErrorKind::CreateDir, path))
 }
 
 /// Wrapper for [`fs::create_dir_all`](https://doc.rust-lang.org/stable/std/fs/fn.create_dir_all.html).
@@ -144,8 +143,7 @@ where
     P: AsRef<Path>,
 {
     let path = path.as_ref();
-    fs::create_dir_all(path)
-        .map_err(|source| Error::new_from_ref(source, ErrorKind::CreateDir, path))
+    fs::create_dir_all(path).map_err(|source| Error::new(source, ErrorKind::CreateDir, path))
 }
 
 /// Wrapper for [`fs::remove_dir`](https://doc.rust-lang.org/stable/std/fs/fn.remove_dir.html).
@@ -154,7 +152,7 @@ where
     P: AsRef<Path>,
 {
     let path = path.as_ref();
-    fs::remove_dir(path).map_err(|source| Error::new_from_ref(source, ErrorKind::RemoveDir, path))
+    fs::remove_dir(path).map_err(|source| Error::new(source, ErrorKind::RemoveDir, path))
 }
 
 /// Wrapper for [`fs::remove_dir_all`](https://doc.rust-lang.org/stable/std/fs/fn.remove_dir_all.html).
@@ -163,8 +161,7 @@ where
     P: AsRef<Path>,
 {
     let path = path.as_ref();
-    fs::remove_dir_all(path)
-        .map_err(|source| Error::new_from_ref(source, ErrorKind::RemoveDir, path))
+    fs::remove_dir_all(path).map_err(|source| Error::new(source, ErrorKind::RemoveDir, path))
 }
 
 /// Wrapper for [`fs::remove_file`](https://doc.rust-lang.org/stable/std/fs/fn.remove_file.html).
@@ -173,44 +170,41 @@ where
     P: AsRef<Path>,
 {
     let path = path.as_ref();
-    fs::remove_file(path).map_err(|source| Error::new_from_ref(source, ErrorKind::RemoveFile, path))
+    fs::remove_file(path).map_err(|source| Error::new(source, ErrorKind::RemoveFile, path))
 }
 
 /// Wrapper for [`fs::metadata`](https://doc.rust-lang.org/stable/std/fs/fn.metadata.html).
 pub fn metadata<P: AsRef<Path>>(path: P) -> io::Result<fs::Metadata> {
     let path = path.as_ref();
-    fs::metadata(path).map_err(|source| Error::new_from_ref(source, ErrorKind::Metadata, path))
+    fs::metadata(path).map_err(|source| Error::new(source, ErrorKind::Metadata, path))
 }
 
 /// Wrapper for [`fs::canonicalize`](https://doc.rust-lang.org/stable/std/fs/fn.canonicalize.html).
 pub fn canonicalize<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
     let path = path.as_ref();
-    fs::canonicalize(path)
-        .map_err(|source| Error::new_from_ref(source, ErrorKind::Canonicalize, path))
+    fs::canonicalize(path).map_err(|source| Error::new(source, ErrorKind::Canonicalize, path))
 }
 
 /// Wrapper for [`fs::hard_link`](https://doc.rust-lang.org/stable/std/fs/fn.hard_link.html).
 pub fn hard_link<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
     let src = src.as_ref();
     let dst = dst.as_ref();
-    fs::hard_link(src, dst).map_err(|source| {
-        SourceDestError::new_from_ref(source, SourceDestErrorKind::HardLink, src, dst)
-    })
+    fs::hard_link(src, dst)
+        .map_err(|source| SourceDestError::new(source, SourceDestErrorKind::HardLink, src, dst))
 }
 
 /// Wrapper for [`fs::read_link`](https://doc.rust-lang.org/stable/std/fs/fn.read_link.html).
 pub fn read_link<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
     let path = path.as_ref();
-    fs::read_link(path).map_err(|source| Error::new_from_ref(source, ErrorKind::ReadLink, path))
+    fs::read_link(path).map_err(|source| Error::new(source, ErrorKind::ReadLink, path))
 }
 
 /// Wrapper for [`fs::rename`](https://doc.rust-lang.org/stable/std/fs/fn.rename.html).
 pub fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<()> {
     let from = from.as_ref();
     let to = to.as_ref();
-    fs::rename(from, to).map_err(|source| {
-        SourceDestError::new_from_ref(source, SourceDestErrorKind::Rename, from, to)
-    })
+    fs::rename(from, to)
+        .map_err(|source| SourceDestError::new(source, SourceDestErrorKind::Rename, from, to))
 }
 
 /// Wrapper for [`fs::soft_link`](https://doc.rust-lang.org/stable/std/fs/fn.soft_link.html).
@@ -220,23 +214,22 @@ pub fn soft_link<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<(
     let src = src.as_ref();
     let dst = dst.as_ref();
     #[allow(deprecated)]
-    fs::soft_link(src, dst).map_err(|source| {
-        SourceDestError::new_from_ref(source, SourceDestErrorKind::SoftLink, src, dst)
-    })
+    fs::soft_link(src, dst)
+        .map_err(|source| SourceDestError::new(source, SourceDestErrorKind::SoftLink, src, dst))
 }
 
 /// Wrapper for [`fs::symlink_metadata`](https://doc.rust-lang.org/stable/std/fs/fn.symlink_metadata.html).
 pub fn symlink_metadata<P: AsRef<Path>>(path: P) -> io::Result<fs::Metadata> {
     let path = path.as_ref();
     fs::symlink_metadata(path)
-        .map_err(|source| Error::new_from_ref(source, ErrorKind::SymlinkMetadata, path))
+        .map_err(|source| Error::new(source, ErrorKind::SymlinkMetadata, path))
 }
 
 /// Wrapper for [`fs::set_permissions`](https://doc.rust-lang.org/stable/std/fs/fn.set_permissions.html).
 pub fn set_permissions<P: AsRef<Path>>(path: P, perm: fs::Permissions) -> io::Result<()> {
     let path = path.as_ref();
     fs::set_permissions(path, perm)
-        .map_err(|source| Error::new_from_ref(source, ErrorKind::SetPermissions, path))
+        .map_err(|source| Error::new(source, ErrorKind::SetPermissions, path))
 }
 
 fn initial_buffer_size(file: &std::fs::File) -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,140 +88,147 @@ pub use open_options::OpenOptions;
 pub use path::PathExt;
 
 /// Wrapper for [`fs::read`](https://doc.rust-lang.org/stable/std/fs/fn.read.html).
-pub fn read<P: AsRef<Path> + Into<PathBuf>>(path: P) -> io::Result<Vec<u8>> {
-    let mut file = File::open(path)?;
+pub fn read<P: Into<PathBuf>>(path: P) -> io::Result<Vec<u8>> {
+    let mut file = File::open(path.into())?;
     let mut bytes = Vec::with_capacity(initial_buffer_size(&file));
     file.read_to_end(&mut bytes)?;
     Ok(bytes)
 }
 
 /// Wrapper for [`fs::read_to_string`](https://doc.rust-lang.org/stable/std/fs/fn.read_to_string.html).
-pub fn read_to_string<P: AsRef<Path> + Into<PathBuf>>(path: P) -> io::Result<String> {
-    let mut file = File::open(path)?;
+pub fn read_to_string<P: Into<PathBuf>>(path: P) -> io::Result<String> {
+    let mut file = File::open(path.into())?;
     let mut string = String::with_capacity(initial_buffer_size(&file));
     file.read_to_string(&mut string)?;
     Ok(string)
 }
 
 /// Wrapper for [`fs::write`](https://doc.rust-lang.org/stable/std/fs/fn.write.html).
-pub fn write<P: AsRef<Path> + Into<PathBuf>, C: AsRef<[u8]>>(
-    path: P,
-    contents: C,
-) -> io::Result<()> {
-    File::create(path)?.write_all(contents.as_ref())
+pub fn write<P: Into<PathBuf>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result<()> {
+    File::create(path.into())?.write_all(contents.as_ref())
 }
 
 /// Wrapper for [`fs::copy`](https://doc.rust-lang.org/stable/std/fs/fn.copy.html).
 pub fn copy<P, Q>(from: P, to: Q) -> io::Result<u64>
 where
-    P: AsRef<Path> + Into<PathBuf>,
-    Q: AsRef<Path> + Into<PathBuf>,
+    P: AsRef<Path>,
+    Q: AsRef<Path>,
 {
-    fs::copy(from.as_ref(), to.as_ref())
-        .map_err(|source| SourceDestError::new(source, SourceDestErrorKind::Copy, from, to))
+    let from = from.as_ref();
+    let to = to.as_ref();
+    fs::copy(from, to).map_err(|source| {
+        SourceDestError::new_from_ref(source, SourceDestErrorKind::Copy, from, to)
+    })
 }
 
 /// Wrapper for [`fs::create_dir`](https://doc.rust-lang.org/stable/std/fs/fn.create_dir.html).
 pub fn create_dir<P>(path: P) -> io::Result<()>
 where
-    P: AsRef<Path> + Into<PathBuf>,
+    P: AsRef<Path>,
 {
-    fs::create_dir(path.as_ref()).map_err(|source| Error::new(source, ErrorKind::CreateDir, path))
+    let path = path.as_ref();
+    fs::create_dir(path).map_err(|source| Error::new_from_ref(source, ErrorKind::CreateDir, path))
 }
 
 /// Wrapper for [`fs::create_dir_all`](https://doc.rust-lang.org/stable/std/fs/fn.create_dir_all.html).
 pub fn create_dir_all<P>(path: P) -> io::Result<()>
 where
-    P: AsRef<Path> + Into<PathBuf>,
+    P: AsRef<Path>,
 {
-    fs::create_dir_all(path.as_ref())
-        .map_err(|source| Error::new(source, ErrorKind::CreateDir, path))
+    let path = path.as_ref();
+    fs::create_dir_all(path)
+        .map_err(|source| Error::new_from_ref(source, ErrorKind::CreateDir, path))
 }
 
 /// Wrapper for [`fs::remove_dir`](https://doc.rust-lang.org/stable/std/fs/fn.remove_dir.html).
 pub fn remove_dir<P>(path: P) -> io::Result<()>
 where
-    P: AsRef<Path> + Into<PathBuf>,
+    P: AsRef<Path>,
 {
-    fs::remove_dir(path.as_ref()).map_err(|source| Error::new(source, ErrorKind::RemoveDir, path))
+    let path = path.as_ref();
+    fs::remove_dir(path).map_err(|source| Error::new_from_ref(source, ErrorKind::RemoveDir, path))
 }
 
 /// Wrapper for [`fs::remove_dir_all`](https://doc.rust-lang.org/stable/std/fs/fn.remove_dir_all.html).
 pub fn remove_dir_all<P>(path: P) -> io::Result<()>
 where
-    P: AsRef<Path> + Into<PathBuf>,
+    P: AsRef<Path>,
 {
-    fs::remove_dir_all(path.as_ref())
-        .map_err(|source| Error::new(source, ErrorKind::RemoveDir, path))
+    let path = path.as_ref();
+    fs::remove_dir_all(path)
+        .map_err(|source| Error::new_from_ref(source, ErrorKind::RemoveDir, path))
 }
 
 /// Wrapper for [`fs::remove_file`](https://doc.rust-lang.org/stable/std/fs/fn.remove_file.html).
 pub fn remove_file<P>(path: P) -> io::Result<()>
 where
-    P: AsRef<Path> + Into<PathBuf>,
+    P: AsRef<Path>,
 {
-    fs::remove_file(path.as_ref()).map_err(|source| Error::new(source, ErrorKind::RemoveFile, path))
+    let path = path.as_ref();
+    fs::remove_file(path).map_err(|source| Error::new_from_ref(source, ErrorKind::RemoveFile, path))
 }
 
 /// Wrapper for [`fs::metadata`](https://doc.rust-lang.org/stable/std/fs/fn.metadata.html).
-pub fn metadata<P: AsRef<Path> + Into<PathBuf>>(path: P) -> io::Result<fs::Metadata> {
-    fs::metadata(path.as_ref()).map_err(|source| Error::new(source, ErrorKind::Metadata, path))
+pub fn metadata<P: AsRef<Path>>(path: P) -> io::Result<fs::Metadata> {
+    let path = path.as_ref();
+    fs::metadata(path).map_err(|source| Error::new_from_ref(source, ErrorKind::Metadata, path))
 }
 
 /// Wrapper for [`fs::canonicalize`](https://doc.rust-lang.org/stable/std/fs/fn.canonicalize.html).
-pub fn canonicalize<P: AsRef<Path> + Into<PathBuf>>(path: P) -> io::Result<PathBuf> {
-    fs::canonicalize(path.as_ref())
-        .map_err(|source| Error::new(source, ErrorKind::Canonicalize, path))
+pub fn canonicalize<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
+    let path = path.as_ref();
+    fs::canonicalize(path)
+        .map_err(|source| Error::new_from_ref(source, ErrorKind::Canonicalize, path))
 }
 
 /// Wrapper for [`fs::hard_link`](https://doc.rust-lang.org/stable/std/fs/fn.hard_link.html).
-pub fn hard_link<P: AsRef<Path> + Into<PathBuf>, Q: AsRef<Path> + Into<PathBuf>>(
-    src: P,
-    dst: Q,
-) -> io::Result<()> {
-    fs::hard_link(src.as_ref(), dst.as_ref())
-        .map_err(|source| SourceDestError::new(source, SourceDestErrorKind::HardLink, src, dst))
+pub fn hard_link<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
+    let src = src.as_ref();
+    let dst = dst.as_ref();
+    fs::hard_link(src, dst).map_err(|source| {
+        SourceDestError::new_from_ref(source, SourceDestErrorKind::HardLink, src, dst)
+    })
 }
 
 /// Wrapper for [`fs::read_link`](https://doc.rust-lang.org/stable/std/fs/fn.read_link.html).
-pub fn read_link<P: AsRef<Path> + Into<PathBuf>>(path: P) -> io::Result<PathBuf> {
-    fs::read_link(path.as_ref()).map_err(|source| Error::new(source, ErrorKind::ReadLink, path))
+pub fn read_link<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
+    let path = path.as_ref();
+    fs::read_link(path).map_err(|source| Error::new_from_ref(source, ErrorKind::ReadLink, path))
 }
 
 /// Wrapper for [`fs::rename`](https://doc.rust-lang.org/stable/std/fs/fn.rename.html).
-pub fn rename<P: AsRef<Path> + Into<PathBuf>, Q: AsRef<Path> + Into<PathBuf>>(
-    from: P,
-    to: Q,
-) -> io::Result<()> {
-    fs::rename(from.as_ref(), to.as_ref())
-        .map_err(|source| SourceDestError::new(source, SourceDestErrorKind::Rename, from, to))
+pub fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<()> {
+    let from = from.as_ref();
+    let to = to.as_ref();
+    fs::rename(from, to).map_err(|source| {
+        SourceDestError::new_from_ref(source, SourceDestErrorKind::Rename, from, to)
+    })
 }
 
 /// Wrapper for [`fs::soft_link`](https://doc.rust-lang.org/stable/std/fs/fn.soft_link.html).
 #[deprecated = "replaced with std::os::unix::fs::symlink and \
 std::os::windows::fs::{symlink_file, symlink_dir}"]
-pub fn soft_link<P: AsRef<Path> + Into<PathBuf>, Q: AsRef<Path> + Into<PathBuf>>(
-    src: P,
-    dst: Q,
-) -> io::Result<()> {
+pub fn soft_link<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
+    let src = src.as_ref();
+    let dst = dst.as_ref();
     #[allow(deprecated)]
-    fs::soft_link(src.as_ref(), dst.as_ref())
-        .map_err(|source| SourceDestError::new(source, SourceDestErrorKind::SoftLink, src, dst))
+    fs::soft_link(src, dst).map_err(|source| {
+        SourceDestError::new_from_ref(source, SourceDestErrorKind::SoftLink, src, dst)
+    })
 }
 
 /// Wrapper for [`fs::symlink_metadata`](https://doc.rust-lang.org/stable/std/fs/fn.symlink_metadata.html).
-pub fn symlink_metadata<P: AsRef<Path> + Into<PathBuf>>(path: P) -> io::Result<fs::Metadata> {
-    fs::symlink_metadata(path.as_ref())
-        .map_err(|source| Error::new(source, ErrorKind::SymlinkMetadata, path))
+pub fn symlink_metadata<P: AsRef<Path>>(path: P) -> io::Result<fs::Metadata> {
+    let path = path.as_ref();
+    fs::symlink_metadata(path)
+        .map_err(|source| Error::new_from_ref(source, ErrorKind::SymlinkMetadata, path))
 }
 
 /// Wrapper for [`fs::set_permissions`](https://doc.rust-lang.org/stable/std/fs/fn.set_permissions.html).
-pub fn set_permissions<P: AsRef<Path> + Into<PathBuf>>(
-    path: P,
-    perm: fs::Permissions,
-) -> io::Result<()> {
-    fs::set_permissions(path.as_ref(), perm)
-        .map_err(|source| Error::new(source, ErrorKind::SetPermissions, path))
+pub fn set_permissions<P: AsRef<Path>>(path: P, perm: fs::Permissions) -> io::Result<()> {
+    let path = path.as_ref();
+    fs::set_permissions(path, perm)
+        .map_err(|source| Error::new_from_ref(source, ErrorKind::SetPermissions, path))
 }
 
 fn initial_buffer_size(file: &File) -> usize {

--- a/src/open_options.rs
+++ b/src/open_options.rs
@@ -1,4 +1,3 @@
-use std::path::Path;
 use std::{fs, io, path::PathBuf};
 #[derive(Clone, Debug)]
 /// Wrapper around [`std::fs::OptionOptions`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html)
@@ -49,14 +48,14 @@ impl OpenOptions {
     /// Wrapper for [`std::fs::OpenOptions::open`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.open)
     pub fn open<P>(&self, path: P) -> io::Result<crate::File>
     where
-        P: AsRef<Path> + Into<PathBuf>,
+        P: Into<PathBuf>,
     {
         // We have to either duplicate the logic or call the deprecated method here.
         // We can't let the deprecated function call this method, because we can't construct
         // `&fs_err::OpenOptions` from `&fs::OpenOptions` without cloning
         // (although cloning would probably be cheap).
         #[allow(deprecated)]
-        crate::File::from_options(path, self.options())
+        crate::File::from_options(path.into(), self.options())
     }
 }
 

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -10,9 +10,8 @@ pub mod fs {
     pub fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
         let src = src.as_ref();
         let dst = dst.as_ref();
-        std::os::unix::fs::symlink(src, dst).map_err(|err| {
-            SourceDestError::new_from_ref(err, SourceDestErrorKind::Symlink, src, dst)
-        })
+        std::os::unix::fs::symlink(src, dst)
+            .map_err(|err| SourceDestError::new(err, SourceDestErrorKind::Symlink, src, dst))
     }
 
     /// Wrapper for [`std::os::unix::fs::FileExt`](https://doc.rust-lang.org/std/os/unix/fs/trait.FileExt.html).

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -1,18 +1,18 @@
 /// Unix-specific extensions to wrappers in `fs_err` for `std::fs` types.
 pub mod fs {
+    use std::io;
     use std::path::Path;
-    use std::{io, path::PathBuf};
 
     use crate::SourceDestError;
     use crate::SourceDestErrorKind;
 
     /// Wrapper for [`std::os::unix::fs::symlink`](https://doc.rust-lang.org/std/os/unix/fs/fn.symlink.html)
-    pub fn symlink<P: AsRef<Path> + Into<PathBuf>, Q: AsRef<Path> + Into<PathBuf>>(
-        src: P,
-        dst: Q,
-    ) -> io::Result<()> {
-        std::os::unix::fs::symlink(src.as_ref(), dst.as_ref())
-            .map_err(|err| SourceDestError::new(err, SourceDestErrorKind::Symlink, src, dst))
+    pub fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
+        let src = src.as_ref();
+        let dst = dst.as_ref();
+        std::os::unix::fs::symlink(src, dst).map_err(|err| {
+            SourceDestError::new_from_ref(err, SourceDestErrorKind::Symlink, src, dst)
+        })
     }
 
     /// Wrapper for [`std::os::unix::fs::FileExt`](https://doc.rust-lang.org/std/os/unix/fs/trait.FileExt.html).

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -4,21 +4,21 @@ pub mod fs {
     use std::io;
     use std::path::{Path, PathBuf};
     /// Wrapper for [std::os::windows::fs::symlink_dir](https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_dir.html)
-    pub fn symlink_dir<P: AsRef<Path> + Into<PathBuf>, Q: AsRef<Path> + Into<PathBuf>>(
-        src: P,
-        dst: Q,
-    ) -> io::Result<()> {
-        std::os::windows::fs::symlink_dir(src.as_ref(), dst.as_ref())
-            .map_err(|err| SourceDestError::new(err, SourceDestErrorKind::SymlinkDir, src, dst))
+    pub fn symlink_dir<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
+        let src = src.as_ref();
+        let dst = dst.as_ref();
+        std::os::windows::fs::symlink_dir(src, dst).map_err(|err| {
+            SourceDestError::new_from_ref(err, SourceDestErrorKind::SymlinkDir, src, dst)
+        })
     }
 
     /// Wrapper for [std::os::windows::fs::symlink_file](https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_file.html)
-    pub fn symlink_file<P: AsRef<Path> + Into<PathBuf>, Q: AsRef<Path> + Into<PathBuf>>(
-        src: P,
-        dst: Q,
-    ) -> io::Result<()> {
-        std::os::windows::fs::symlink_file(src.as_ref(), dst.as_ref())
-            .map_err(|err| SourceDestError::new(err, SourceDestErrorKind::SymlinkFile, src, dst))
+    pub fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
+        let src = src.as_ref();
+        let dst = dst.as_ref();
+        std::os::windows::fs::symlink_file(src, dst).map_err(|err| {
+            SourceDestError::new_from_ref(err, SourceDestErrorKind::SymlinkFile, src, dst)
+        })
     }
 
     /// Wrapper for [`std::os::windows::fs::FileExt`](https://doc.rust-lang.org/std/os/windows/fs/trait.FileExt.html).

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -7,18 +7,16 @@ pub mod fs {
     pub fn symlink_dir<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
         let src = src.as_ref();
         let dst = dst.as_ref();
-        std::os::windows::fs::symlink_dir(src, dst).map_err(|err| {
-            SourceDestError::new_from_ref(err, SourceDestErrorKind::SymlinkDir, src, dst)
-        })
+        std::os::windows::fs::symlink_dir(src, dst)
+            .map_err(|err| SourceDestError::new(err, SourceDestErrorKind::SymlinkDir, src, dst))
     }
 
     /// Wrapper for [std::os::windows::fs::symlink_file](https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_file.html)
     pub fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
         let src = src.as_ref();
         let dst = dst.as_ref();
-        std::os::windows::fs::symlink_file(src, dst).map_err(|err| {
-            SourceDestError::new_from_ref(err, SourceDestErrorKind::SymlinkFile, src, dst)
-        })
+        std::os::windows::fs::symlink_file(src, dst)
+            .map_err(|err| SourceDestError::new(err, SourceDestErrorKind::SymlinkFile, src, dst))
     }
 
     /// Wrapper for [`std::os::windows::fs::FileExt`](https://doc.rust-lang.org/std/os/windows/fs/trait.FileExt.html).


### PR DESCRIPTION
Fixes #23.

* Most functions only need a `PathBuf` in the error case. We can just call `as_ref()` early and build a PathBuf in the error case. We can then also leave out the `Into<PathBuf>` bound.
  This is done wherever possible.
* A few APIs always need a `PathBuf`. For those `Into<PathBuf>` is more efficient and the speedup potentially important.
  It does mean that the API differs from `std`. That causes incompatibility for users who write generic functions themselves which follow the `std` convention of taking `AsRef<Path>`. They can't use `fs_err` inside those without code changes, but the necessary changes are very minor.
  This is done for `fs_err::File` constructors and `fs_err::read_dir`.
* Three functions always construct a `PathBuf`, but don't actually need it. They only do because of implementation detaiils.
  All of these have been adapted to require only `AsRef<Path>`. The functions are: `fs_err::{read, read_to_string, write}`

No trait bounds were added, only removed. That makes the change backwards compatible.