### PR TITLE
Fix clippy and ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,19 +20,36 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v2
 
       - name: Setup Rust toolchain
-        run: rustup default ${{ matrix.rust_version }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust_version }}
+          override: true
+          components: rustfmt, clippy
 
-      - name: Build
-        run: cargo build --all --verbose
+      - name: cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
 
-      - name: Run tests
-        run: cargo test --all --verbose
+      - name: cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
 
-      - name: Rustfmt and Clippy
-        run: |
-          cargo fmt -- --check
-          cargo clippy
-        if: matrix.rust_version == 'stable'
+      - name: cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+        if:  matrix.rust_version == 'stable'
+
+      - name: cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --tests -- -D warnings
+        if:  matrix.rust_version == 'stable'

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -10,8 +10,8 @@ pub fn read_dir<P: Into<PathBuf>>(path: P) -> io::Result<ReadDir> {
     let path = path.into();
 
     match fs::read_dir(&path) {
-        Ok(inner) => Ok(ReadDir { inner, path }),
-        Err(source) => Err(Error::new(source, ErrorKind::ReadDir, path)),
+        Ok(inner) => Ok(ReadDir { inner }),
+        Err(source) => Err(Error::build(source, ErrorKind::ReadDir, path)),
     }
 }
 
@@ -25,7 +25,6 @@ pub fn read_dir<P: Into<PathBuf>>(path: P) -> io::Result<ReadDir> {
 #[derive(Debug)]
 pub struct ReadDir {
     inner: fs::ReadDir,
-    path: PathBuf,
 }
 
 impl Iterator for ReadDir {
@@ -55,14 +54,14 @@ impl DirEntry {
     pub fn metadata(&self) -> io::Result<fs::Metadata> {
         self.inner
             .metadata()
-            .map_err(|source| Error::new(source, ErrorKind::Metadata, self.path()))
+            .map_err(|source| Error::build(source, ErrorKind::Metadata, self.path()))
     }
 
     /// Wrapper for [`DirEntry::file_type`](https://doc.rust-lang.org/stable/std/fs/struct.DirEntry.html#method.file_type).
     pub fn file_type(&self) -> io::Result<fs::FileType> {
         self.inner
             .file_type()
-            .map_err(|source| Error::new(source, ErrorKind::Metadata, self.path()))
+            .map_err(|source| Error::build(source, ErrorKind::Metadata, self.path()))
     }
 
     /// Wrapper for [`DirEntry::file_name`](https://doc.rust-lang.org/stable/std/fs/struct.DirEntry.html#method.file_name).

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -47,12 +47,15 @@ pub(crate) struct Error {
 }
 
 impl Error {
-    pub fn new(source: io::Error, kind: ErrorKind, path: impl Into<PathBuf>) -> io::Error {
-        Self::_new(source, kind, path.into())
-    }
-
-    fn _new(source: io::Error, kind: ErrorKind, path: PathBuf) -> io::Error {
-        io::Error::new(source.kind(), Self { kind, source, path })
+    pub fn build(source: io::Error, kind: ErrorKind, path: impl Into<PathBuf>) -> io::Error {
+        io::Error::new(
+            source.kind(),
+            Self {
+                kind,
+                source,
+                path: path.into(),
+            },
+        )
     }
 }
 
@@ -131,28 +134,19 @@ pub(crate) struct SourceDestError {
 }
 
 impl SourceDestError {
-    pub fn new(
+    pub fn build(
         source: io::Error,
         kind: SourceDestErrorKind,
         from_path: impl Into<PathBuf>,
         to_path: impl Into<PathBuf>,
-    ) -> io::Error {
-        Self::_new(source, kind, from_path.into(), to_path.into())
-    }
-
-    fn _new(
-        source: io::Error,
-        kind: SourceDestErrorKind,
-        from_path: PathBuf,
-        to_path: PathBuf,
     ) -> io::Error {
         io::Error::new(
             source.kind(),
             Self {
                 kind,
                 source,
-                from_path,
-                to_path,
+                from_path: from_path.into(),
+                to_path: to_path.into(),
             },
         )
     }

--- a/src/file.rs
+++ b/src/file.rs
@@ -17,12 +17,12 @@ pub struct File {
 // Opens a std File and returns it or an error generator which only needs the path to produce the error.
 // Exists for the `crate::read*` functions so they don't unconditionally build a PathBuf.
 pub(crate) fn open(path: &Path) -> Result<std::fs::File, impl FnOnce(PathBuf) -> io::Error> {
-    fs::File::open(&path).map_err(|err| |path| Error::new(err, ErrorKind::OpenFile, path))
+    fs::File::open(&path).map_err(|err| |path| Error::build(err, ErrorKind::OpenFile, path))
 }
 
 // like `open()` but for `crate::write`
 pub(crate) fn create(path: &Path) -> Result<std::fs::File, impl FnOnce(PathBuf) -> io::Error> {
-    fs::File::create(&path).map_err(|err| |path| Error::new(err, ErrorKind::CreateFile, path))
+    fs::File::create(&path).map_err(|err| |path| Error::build(err, ErrorKind::CreateFile, path))
 }
 
 /// Wrappers for methods from [`std::fs::File`][std::fs::File].
@@ -65,7 +65,7 @@ impl File {
         let path = path.into();
         match options.open(&path) {
             Ok(file) => Ok(File::from_parts(file, path)),
-            Err(source) => Err(Error::new(source, ErrorKind::OpenFile, path)),
+            Err(source) => Err(Error::build(source, ErrorKind::OpenFile, path)),
         }
     }
 
@@ -158,7 +158,7 @@ impl File {
 
     /// Wrap the error in information specific to this `File` object.
     fn error(&self, source: io::Error, kind: ErrorKind) -> io::Error {
-        Error::new(source, kind, &self.path)
+        Error::build(source, kind, &self.path)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,20 +90,20 @@ pub use path::PathExt;
 /// Wrapper for [`fs::read`](https://doc.rust-lang.org/stable/std/fs/fn.read.html).
 pub fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
     let path = path.as_ref();
-    let mut file = file::open(path.as_ref()).map_err(|err_gen| err_gen(path.to_path_buf()))?;
+    let mut file = file::open(path).map_err(|err_gen| err_gen(path.to_path_buf()))?;
     let mut bytes = Vec::with_capacity(initial_buffer_size(&file));
     file.read_to_end(&mut bytes)
-        .map_err(|err| Error::new(err, ErrorKind::Read, path))?;
+        .map_err(|err| Error::build(err, ErrorKind::Read, path))?;
     Ok(bytes)
 }
 
 /// Wrapper for [`fs::read_to_string`](https://doc.rust-lang.org/stable/std/fs/fn.read_to_string.html).
 pub fn read_to_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
     let path = path.as_ref();
-    let mut file = file::open(path.as_ref()).map_err(|err_gen| err_gen(path.to_path_buf()))?;
+    let mut file = file::open(path).map_err(|err_gen| err_gen(path.to_path_buf()))?;
     let mut string = String::with_capacity(initial_buffer_size(&file));
     file.read_to_string(&mut string)
-        .map_err(|err| Error::new(err, ErrorKind::Read, path))?;
+        .map_err(|err| Error::build(err, ErrorKind::Read, path))?;
     Ok(string)
 }
 
@@ -113,7 +113,7 @@ pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result
     file::create(path)
         .map_err(|err_gen| err_gen(path.to_path_buf()))?
         .write_all(contents.as_ref())
-        .map_err(|err| Error::new(err, ErrorKind::Write, path))
+        .map_err(|err| Error::build(err, ErrorKind::Write, path))
 }
 
 /// Wrapper for [`fs::copy`](https://doc.rust-lang.org/stable/std/fs/fn.copy.html).
@@ -125,7 +125,7 @@ where
     let from = from.as_ref();
     let to = to.as_ref();
     fs::copy(from, to)
-        .map_err(|source| SourceDestError::new(source, SourceDestErrorKind::Copy, from, to))
+        .map_err(|source| SourceDestError::build(source, SourceDestErrorKind::Copy, from, to))
 }
 
 /// Wrapper for [`fs::create_dir`](https://doc.rust-lang.org/stable/std/fs/fn.create_dir.html).
@@ -134,7 +134,7 @@ where
     P: AsRef<Path>,
 {
     let path = path.as_ref();
-    fs::create_dir(path).map_err(|source| Error::new(source, ErrorKind::CreateDir, path))
+    fs::create_dir(path).map_err(|source| Error::build(source, ErrorKind::CreateDir, path))
 }
 
 /// Wrapper for [`fs::create_dir_all`](https://doc.rust-lang.org/stable/std/fs/fn.create_dir_all.html).
@@ -143,7 +143,7 @@ where
     P: AsRef<Path>,
 {
     let path = path.as_ref();
-    fs::create_dir_all(path).map_err(|source| Error::new(source, ErrorKind::CreateDir, path))
+    fs::create_dir_all(path).map_err(|source| Error::build(source, ErrorKind::CreateDir, path))
 }
 
 /// Wrapper for [`fs::remove_dir`](https://doc.rust-lang.org/stable/std/fs/fn.remove_dir.html).
@@ -152,7 +152,7 @@ where
     P: AsRef<Path>,
 {
     let path = path.as_ref();
-    fs::remove_dir(path).map_err(|source| Error::new(source, ErrorKind::RemoveDir, path))
+    fs::remove_dir(path).map_err(|source| Error::build(source, ErrorKind::RemoveDir, path))
 }
 
 /// Wrapper for [`fs::remove_dir_all`](https://doc.rust-lang.org/stable/std/fs/fn.remove_dir_all.html).
@@ -161,7 +161,7 @@ where
     P: AsRef<Path>,
 {
     let path = path.as_ref();
-    fs::remove_dir_all(path).map_err(|source| Error::new(source, ErrorKind::RemoveDir, path))
+    fs::remove_dir_all(path).map_err(|source| Error::build(source, ErrorKind::RemoveDir, path))
 }
 
 /// Wrapper for [`fs::remove_file`](https://doc.rust-lang.org/stable/std/fs/fn.remove_file.html).
@@ -170,19 +170,19 @@ where
     P: AsRef<Path>,
 {
     let path = path.as_ref();
-    fs::remove_file(path).map_err(|source| Error::new(source, ErrorKind::RemoveFile, path))
+    fs::remove_file(path).map_err(|source| Error::build(source, ErrorKind::RemoveFile, path))
 }
 
 /// Wrapper for [`fs::metadata`](https://doc.rust-lang.org/stable/std/fs/fn.metadata.html).
 pub fn metadata<P: AsRef<Path>>(path: P) -> io::Result<fs::Metadata> {
     let path = path.as_ref();
-    fs::metadata(path).map_err(|source| Error::new(source, ErrorKind::Metadata, path))
+    fs::metadata(path).map_err(|source| Error::build(source, ErrorKind::Metadata, path))
 }
 
 /// Wrapper for [`fs::canonicalize`](https://doc.rust-lang.org/stable/std/fs/fn.canonicalize.html).
 pub fn canonicalize<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
     let path = path.as_ref();
-    fs::canonicalize(path).map_err(|source| Error::new(source, ErrorKind::Canonicalize, path))
+    fs::canonicalize(path).map_err(|source| Error::build(source, ErrorKind::Canonicalize, path))
 }
 
 /// Wrapper for [`fs::hard_link`](https://doc.rust-lang.org/stable/std/fs/fn.hard_link.html).
@@ -190,13 +190,13 @@ pub fn hard_link<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<(
     let src = src.as_ref();
     let dst = dst.as_ref();
     fs::hard_link(src, dst)
-        .map_err(|source| SourceDestError::new(source, SourceDestErrorKind::HardLink, src, dst))
+        .map_err(|source| SourceDestError::build(source, SourceDestErrorKind::HardLink, src, dst))
 }
 
 /// Wrapper for [`fs::read_link`](https://doc.rust-lang.org/stable/std/fs/fn.read_link.html).
 pub fn read_link<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
     let path = path.as_ref();
-    fs::read_link(path).map_err(|source| Error::new(source, ErrorKind::ReadLink, path))
+    fs::read_link(path).map_err(|source| Error::build(source, ErrorKind::ReadLink, path))
 }
 
 /// Wrapper for [`fs::rename`](https://doc.rust-lang.org/stable/std/fs/fn.rename.html).
@@ -204,7 +204,7 @@ pub fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<()> 
     let from = from.as_ref();
     let to = to.as_ref();
     fs::rename(from, to)
-        .map_err(|source| SourceDestError::new(source, SourceDestErrorKind::Rename, from, to))
+        .map_err(|source| SourceDestError::build(source, SourceDestErrorKind::Rename, from, to))
 }
 
 /// Wrapper for [`fs::soft_link`](https://doc.rust-lang.org/stable/std/fs/fn.soft_link.html).
@@ -215,21 +215,21 @@ pub fn soft_link<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<(
     let dst = dst.as_ref();
     #[allow(deprecated)]
     fs::soft_link(src, dst)
-        .map_err(|source| SourceDestError::new(source, SourceDestErrorKind::SoftLink, src, dst))
+        .map_err(|source| SourceDestError::build(source, SourceDestErrorKind::SoftLink, src, dst))
 }
 
 /// Wrapper for [`fs::symlink_metadata`](https://doc.rust-lang.org/stable/std/fs/fn.symlink_metadata.html).
 pub fn symlink_metadata<P: AsRef<Path>>(path: P) -> io::Result<fs::Metadata> {
     let path = path.as_ref();
     fs::symlink_metadata(path)
-        .map_err(|source| Error::new(source, ErrorKind::SymlinkMetadata, path))
+        .map_err(|source| Error::build(source, ErrorKind::SymlinkMetadata, path))
 }
 
 /// Wrapper for [`fs::set_permissions`](https://doc.rust-lang.org/stable/std/fs/fn.set_permissions.html).
 pub fn set_permissions<P: AsRef<Path>>(path: P, perm: fs::Permissions) -> io::Result<()> {
     let path = path.as_ref();
     fs::set_permissions(path, perm)
-        .map_err(|source| Error::new(source, ErrorKind::SetPermissions, path))
+        .map_err(|source| Error::build(source, ErrorKind::SetPermissions, path))
 }
 
 fn initial_buffer_size(file: &std::fs::File) -> usize {

--- a/src/open_options.rs
+++ b/src/open_options.rs
@@ -5,6 +5,7 @@ pub struct OpenOptions(fs::OpenOptions);
 
 impl OpenOptions {
     /// Wrapper for [`std::fs::OpenOptions::new`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.new)
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         OpenOptions(fs::OpenOptions::new())
     }

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -11,7 +11,7 @@ pub mod fs {
         let src = src.as_ref();
         let dst = dst.as_ref();
         std::os::unix::fs::symlink(src, dst)
-            .map_err(|err| SourceDestError::new(err, SourceDestErrorKind::Symlink, src, dst))
+            .map_err(|err| SourceDestError::build(err, SourceDestErrorKind::Symlink, src, dst))
     }
 
     /// Wrapper for [`std::os::unix::fs::FileExt`](https://doc.rust-lang.org/std/os/unix/fs/trait.FileExt.html).

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -8,7 +8,7 @@ pub mod fs {
         let src = src.as_ref();
         let dst = dst.as_ref();
         std::os::windows::fs::symlink_dir(src, dst)
-            .map_err(|err| SourceDestError::new(err, SourceDestErrorKind::SymlinkDir, src, dst))
+            .map_err(|err| SourceDestError::build(err, SourceDestErrorKind::SymlinkDir, src, dst))
     }
 
     /// Wrapper for [std::os::windows::fs::symlink_file](https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_file.html)
@@ -16,7 +16,7 @@ pub mod fs {
         let src = src.as_ref();
         let dst = dst.as_ref();
         std::os::windows::fs::symlink_file(src, dst)
-            .map_err(|err| SourceDestError::new(err, SourceDestErrorKind::SymlinkFile, src, dst))
+            .map_err(|err| SourceDestError::build(err, SourceDestErrorKind::SymlinkFile, src, dst))
     }
 
     /// Wrapper for [`std::os::windows::fs::FileExt`](https://doc.rust-lang.org/std/os/windows/fs/trait.FileExt.html).


### PR DESCRIPTION
First of all, thanks for providing this library. I'm currently thinking about using it in my projects :).

1. Fixes clippy issues
2. Fixes naming of `Error::new()`. `new()` is paradigmatically used as a constructor call, but in this case `Error::new()` was building a new io::Error instead of the library internal `Error`.
3. The CI wasn't properly reporting clippy warnings. I streamlined it to the current de-facto standard that's used by many established projects.