### PR TITLE
Add Into impl for std::fs::File

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -190,6 +190,12 @@ impl<'a> Read for &'a File {
     }
 }
 
+impl From<File> for fs::File {
+    fn from(file: File) -> Self {
+        file.into_parts().0
+    }
+}
+
 impl Seek for File {
     fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
         self.file


### PR DESCRIPTION
This adds the `.into()` and `.from()` traits to easily convert a `fs_err::File` into an `std::fs::File`.

Calling `file.into()` is quite a bit more intuitive and elegant than calling `file.into_parts().0`.
This especially useful when using` fs-err` in libraries if one doesn't want to expose the `fs-err::File` type.