### PR TITLE
Implement I/O safety traits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,10 @@ jobs:
           command: clippy
           args: --tests -- -D warnings
         if:  matrix.rust_version == 'stable'
+
+      - name: cargo check --features io_safety
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --features io_safety
+        if:  matrix.rust_version == 'stable'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ exclude = [".github", ".gitignore", "README.tpl"]
 [dev-dependencies]
 serde_json = "1.0.64"
 
+[features]
+# Adds I/O safety traits introduced in Rust 1.63
+io_safety = []
+
 [package.metadata.release]
 tag-name = "{{version}}"
 sign-tag = true

--- a/src/file.rs
+++ b/src/file.rs
@@ -284,6 +284,23 @@ mod unix {
                 .map_err(|err| self.error(err, ErrorKind::WriteAt))
         }
     }
+
+    #[cfg(feature = "io_safety")]
+    mod io_safety {
+        use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd};
+
+        impl AsFd for crate::File {
+            fn as_fd(&self) -> BorrowedFd<'_> {
+                self.file().as_fd()
+            }
+        }
+
+        impl From<crate::File> for OwnedFd {
+            fn from(file: crate::File) -> Self {
+                file.into_parts().0.into()
+            }
+        }
+    }
 }
 
 #[cfg(windows)]
@@ -323,6 +340,23 @@ mod windows {
     impl IntoRawHandle for crate::File {
         fn into_raw_handle(self) -> RawHandle {
             self.file.into_raw_handle()
+        }
+    }
+
+    #[cfg(feature = "io_safety")]
+    mod io_safety {
+        use std::os::windows::io::{AsHandle, BorrowedHandle, OwnedHandle};
+
+        impl AsHandle for crate::File {
+            fn as_handle(&self) -> BorrowedHandle<'_> {
+                self.file().as_handle()
+            }
+        }
+
+        impl From<crate::File> for OwnedHandle {
+            fn from(file: crate::File) -> Self {
+                file.into_parts().0.into()
+            }
         }
     }
 }


### PR DESCRIPTION
This PR implements I/O safety traits on `File`. I implemented `AsFd/AsHandle` and `Into<OwnedFd/OwnedHandle>`, although I wasn't able to implement `From<OwnedFd>` since that does not come with path information.

See also: sunfishcode/io-lifetimes#38