### PR TITLE
Improve rustdoc of wrapped functions

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -5,6 +5,8 @@ use std::path::PathBuf;
 
 use crate::errors::{Error, ErrorKind};
 
+/// Returns an iterator over the entries within a directory.
+///
 /// Wrapper for [`fs::read_dir`](https://doc.rust-lang.org/stable/std/fs/fn.read_dir.html).
 pub fn read_dir<P: Into<PathBuf>>(path: P) -> io::Result<ReadDir> {
     let path = path.into();
@@ -51,11 +53,15 @@ pub struct DirEntry {
 }
 
 impl DirEntry {
+    /// Returns the full path to the file that this entry represents.
+    ///
     /// Wrapper for [`DirEntry::path`](https://doc.rust-lang.org/stable/std/fs/struct.DirEntry.html#method.path).
     pub fn path(&self) -> PathBuf {
         self.inner.path()
     }
 
+    /// Returns the metadata for the file that this entry points at.
+    ///
     /// Wrapper for [`DirEntry::metadata`](https://doc.rust-lang.org/stable/std/fs/struct.DirEntry.html#method.metadata).
     pub fn metadata(&self) -> io::Result<fs::Metadata> {
         self.inner
@@ -63,6 +69,8 @@ impl DirEntry {
             .map_err(|source| Error::build(source, ErrorKind::Metadata, self.path()))
     }
 
+    /// Returns the file type for the file that this entry points at.
+    ///
     /// Wrapper for [`DirEntry::file_type`](https://doc.rust-lang.org/stable/std/fs/struct.DirEntry.html#method.file_type).
     pub fn file_type(&self) -> io::Result<fs::FileType> {
         self.inner
@@ -70,6 +78,8 @@ impl DirEntry {
             .map_err(|source| Error::build(source, ErrorKind::Metadata, self.path()))
     }
 
+    /// Returns the file name of this directory entry without any leading path component(s).
+    ///
     /// Wrapper for [`DirEntry::file_name`](https://doc.rust-lang.org/stable/std/fs/struct.DirEntry.html#method.file_name).
     pub fn file_name(&self) -> OsString {
         self.inner.file_name()

--- a/src/file.rs
+++ b/src/file.rs
@@ -29,6 +29,8 @@ pub(crate) fn create(path: &Path) -> Result<std::fs::File, impl FnOnce(PathBuf) 
 ///
 /// [std::fs::File]: https://doc.rust-lang.org/stable/std/fs/struct.File.html
 impl File {
+    /// Attempts to open a file in read-only mode.
+    ///
     /// Wrapper for [`File::open`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.open).
     pub fn open<P>(path: P) -> Result<Self, io::Error>
     where
@@ -41,6 +43,8 @@ impl File {
         }
     }
 
+    /// Opens a file in write-only mode.
+    ///
     /// Wrapper for [`File::create`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.create).
     pub fn create<P>(path: P) -> Result<Self, io::Error>
     where
@@ -69,6 +73,8 @@ impl File {
         }
     }
 
+    /// Attempts to sync all OS-internal metadata to disk.
+    ///
     /// Wrapper for [`File::sync_all`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.sync_all).
     pub fn sync_all(&self) -> Result<(), io::Error> {
         self.file
@@ -76,6 +82,8 @@ impl File {
             .map_err(|source| self.error(source, ErrorKind::SyncFile))
     }
 
+    /// This function is similar to [`sync_all`], except that it might not synchronize file metadata to the filesystem.
+    ///
     /// Wrapper for [`File::sync_data`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.sync_data).
     pub fn sync_data(&self) -> Result<(), io::Error> {
         self.file
@@ -83,6 +91,8 @@ impl File {
             .map_err(|source| self.error(source, ErrorKind::SyncFile))
     }
 
+    /// Truncates or extends the underlying file, updating the size of this file to become `size`.
+    ///
     /// Wrapper for [`File::set_len`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.set_len).
     pub fn set_len(&self, size: u64) -> Result<(), io::Error> {
         self.file
@@ -90,6 +100,8 @@ impl File {
             .map_err(|source| self.error(source, ErrorKind::SetLen))
     }
 
+    /// Queries metadata about the underlying file.
+    ///
     /// Wrapper for [`File::metadata`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.metadata).
     pub fn metadata(&self) -> Result<fs::Metadata, io::Error> {
         self.file
@@ -97,6 +109,10 @@ impl File {
             .map_err(|source| self.error(source, ErrorKind::Metadata))
     }
 
+    /// Creates a new `File` instance that shares the same underlying file handle as the
+    /// existing `File` instance. Reads, writes, and seeks will affect both `File`
+    /// instances simultaneously.
+    ///
     /// Wrapper for [`File::try_clone`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.try_clone).
     pub fn try_clone(&self) -> Result<Self, io::Error> {
         self.file
@@ -108,6 +124,8 @@ impl File {
             .map_err(|source| self.error(source, ErrorKind::Clone))
     }
 
+    /// Changes the permissions on the underlying file.
+    ///
     /// Wrapper for [`File::set_permissions`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.set_permissions).
     pub fn set_permissions(&self, perm: fs::Permissions) -> Result<(), io::Error> {
         self.file

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,8 @@ pub use file::*;
 pub use open_options::OpenOptions;
 pub use path::PathExt;
 
+/// Read the entire contents of a file into a bytes vector.
+///
 /// Wrapper for [`fs::read`](https://doc.rust-lang.org/stable/std/fs/fn.read.html).
 pub fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
     let path = path.as_ref();
@@ -101,6 +103,8 @@ pub fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
     Ok(bytes)
 }
 
+/// Read the entire contents of a file into a string.
+///
 /// Wrapper for [`fs::read_to_string`](https://doc.rust-lang.org/stable/std/fs/fn.read_to_string.html).
 pub fn read_to_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
     let path = path.as_ref();
@@ -111,6 +115,8 @@ pub fn read_to_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
     Ok(string)
 }
 
+/// Write a slice as the entire contents of a file.
+///
 /// Wrapper for [`fs::write`](https://doc.rust-lang.org/stable/std/fs/fn.write.html).
 pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result<()> {
     let path = path.as_ref();
@@ -120,6 +126,9 @@ pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result
         .map_err(|err| Error::build(err, ErrorKind::Write, path))
 }
 
+/// Copies the contents of one file to another. This function will also copy the
+/// permission bits of the original file to the destination file.
+///
 /// Wrapper for [`fs::copy`](https://doc.rust-lang.org/stable/std/fs/fn.copy.html).
 pub fn copy<P, Q>(from: P, to: Q) -> io::Result<u64>
 where
@@ -132,6 +141,8 @@ where
         .map_err(|source| SourceDestError::build(source, SourceDestErrorKind::Copy, from, to))
 }
 
+/// Creates a new, empty directory at the provided path.
+///
 /// Wrapper for [`fs::create_dir`](https://doc.rust-lang.org/stable/std/fs/fn.create_dir.html).
 pub fn create_dir<P>(path: P) -> io::Result<()>
 where
@@ -141,6 +152,8 @@ where
     fs::create_dir(path).map_err(|source| Error::build(source, ErrorKind::CreateDir, path))
 }
 
+/// Recursively create a directory and all of its parent components if they are missing.
+///
 /// Wrapper for [`fs::create_dir_all`](https://doc.rust-lang.org/stable/std/fs/fn.create_dir_all.html).
 pub fn create_dir_all<P>(path: P) -> io::Result<()>
 where
@@ -150,6 +163,8 @@ where
     fs::create_dir_all(path).map_err(|source| Error::build(source, ErrorKind::CreateDir, path))
 }
 
+/// Removes an empty directory.
+///
 /// Wrapper for [`fs::remove_dir`](https://doc.rust-lang.org/stable/std/fs/fn.remove_dir.html).
 pub fn remove_dir<P>(path: P) -> io::Result<()>
 where
@@ -159,6 +174,8 @@ where
     fs::remove_dir(path).map_err(|source| Error::build(source, ErrorKind::RemoveDir, path))
 }
 
+/// Removes a directory at this path, after removing all its contents. Use carefully!
+///
 /// Wrapper for [`fs::remove_dir_all`](https://doc.rust-lang.org/stable/std/fs/fn.remove_dir_all.html).
 pub fn remove_dir_all<P>(path: P) -> io::Result<()>
 where
@@ -168,6 +185,8 @@ where
     fs::remove_dir_all(path).map_err(|source| Error::build(source, ErrorKind::RemoveDir, path))
 }
 
+/// Removes a file from the filesystem.
+///
 /// Wrapper for [`fs::remove_file`](https://doc.rust-lang.org/stable/std/fs/fn.remove_file.html).
 pub fn remove_file<P>(path: P) -> io::Result<()>
 where
@@ -177,18 +196,25 @@ where
     fs::remove_file(path).map_err(|source| Error::build(source, ErrorKind::RemoveFile, path))
 }
 
+/// Given a path, query the file system to get information about a file, directory, etc.
+///
 /// Wrapper for [`fs::metadata`](https://doc.rust-lang.org/stable/std/fs/fn.metadata.html).
 pub fn metadata<P: AsRef<Path>>(path: P) -> io::Result<fs::Metadata> {
     let path = path.as_ref();
     fs::metadata(path).map_err(|source| Error::build(source, ErrorKind::Metadata, path))
 }
 
+/// Returns the canonical, absolute form of a path with all intermediate components
+/// normalized and symbolic links resolved.
+///
 /// Wrapper for [`fs::canonicalize`](https://doc.rust-lang.org/stable/std/fs/fn.canonicalize.html).
 pub fn canonicalize<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
     let path = path.as_ref();
     fs::canonicalize(path).map_err(|source| Error::build(source, ErrorKind::Canonicalize, path))
 }
 
+/// Creates a new hard link on the filesystem.
+///
 /// Wrapper for [`fs::hard_link`](https://doc.rust-lang.org/stable/std/fs/fn.hard_link.html).
 pub fn hard_link<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
     let src = src.as_ref();
@@ -197,12 +223,16 @@ pub fn hard_link<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<(
         .map_err(|source| SourceDestError::build(source, SourceDestErrorKind::HardLink, src, dst))
 }
 
+/// Reads a symbolic link, returning the file that the link points to.
+///
 /// Wrapper for [`fs::read_link`](https://doc.rust-lang.org/stable/std/fs/fn.read_link.html).
 pub fn read_link<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
     let path = path.as_ref();
     fs::read_link(path).map_err(|source| Error::build(source, ErrorKind::ReadLink, path))
 }
 
+/// Rename a file or directory to a new name, replacing the original file if to already exists.
+///
 /// Wrapper for [`fs::rename`](https://doc.rust-lang.org/stable/std/fs/fn.rename.html).
 pub fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<()> {
     let from = from.as_ref();
@@ -222,6 +252,8 @@ pub fn soft_link<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<(
         .map_err(|source| SourceDestError::build(source, SourceDestErrorKind::SoftLink, src, dst))
 }
 
+/// Query the metadata about a file without following symlinks.
+///
 /// Wrapper for [`fs::symlink_metadata`](https://doc.rust-lang.org/stable/std/fs/fn.symlink_metadata.html).
 pub fn symlink_metadata<P: AsRef<Path>>(path: P) -> io::Result<fs::Metadata> {
     let path = path.as_ref();
@@ -229,6 +261,8 @@ pub fn symlink_metadata<P: AsRef<Path>>(path: P) -> io::Result<fs::Metadata> {
         .map_err(|source| Error::build(source, ErrorKind::SymlinkMetadata, path))
 }
 
+/// Changes the permissions found on a file or a directory.
+///
 /// Wrapper for [`fs::set_permissions`](https://doc.rust-lang.org/stable/std/fs/fn.set_permissions.html).
 pub fn set_permissions<P: AsRef<Path>>(path: P, perm: fs::Permissions) -> io::Result<()> {
     let path = path.as_ref();

--- a/src/open_options.rs
+++ b/src/open_options.rs
@@ -4,48 +4,64 @@ use std::{fs, io, path::PathBuf};
 pub struct OpenOptions(fs::OpenOptions);
 
 impl OpenOptions {
+    /// Creates a blank new set of options ready for configuration.
+    ///
     /// Wrapper for [`std::fs::OpenOptions::new`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.new)
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         OpenOptions(fs::OpenOptions::new())
     }
 
+    /// Sets the option for read access.
+    ///
     /// Wrapper for [`std::fs::OpenOptions::read`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.read)
     pub fn read(&mut self, read: bool) -> &mut Self {
         self.0.read(read);
         self
     }
 
+    /// Sets the option for write access.
+    ///
     /// Wrapper for [`std::fs::OpenOptions::write`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.write)
     pub fn write(&mut self, write: bool) -> &mut Self {
         self.0.write(write);
         self
     }
 
+    /// Sets the option for the append mode.
+    ///
     /// Wrapper for [`std::fs::OpenOptions::append`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.append)
     pub fn append(&mut self, append: bool) -> &mut Self {
         self.0.append(append);
         self
     }
 
+    /// Sets the option for truncating a previous file.
+    ///
     /// Wrapper for [`std::fs::OpenOptions::truncate`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.truncate)
     pub fn truncate(&mut self, truncate: bool) -> &mut Self {
         self.0.truncate(truncate);
         self
     }
 
+    /// Sets the option to create a new file, or open it if it already exists.
+    ///
     /// Wrapper for [`std::fs::OpenOptions::create`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.create)
     pub fn create(&mut self, create: bool) -> &mut Self {
         self.0.create(create);
         self
     }
 
+    /// Sets the option to create a new file, failing if it already exists.
+    ///
     /// Wrapper for [`std::fs::OpenOptions::create_new`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.create_new)
     pub fn create_new(&mut self, create_new: bool) -> &mut Self {
         self.0.create_new(create_new);
         self
     }
 
+    /// Opens a file at `path` with the options specified by `self`.
+    ///
     /// Wrapper for [`std::fs::OpenOptions::open`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.open)
     pub fn open<P>(&self, path: P) -> io::Result<crate::File>
     where

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -6,6 +6,8 @@ pub mod fs {
     use crate::SourceDestError;
     use crate::SourceDestErrorKind;
 
+    /// Creates a new symbolic link on the filesystem.
+    ///
     /// Wrapper for [`std::os::unix::fs::symlink`](https://doc.rust-lang.org/std/os/unix/fs/fn.symlink.html)
     pub fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
         let src = src.as_ref();

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -3,6 +3,9 @@ pub mod fs {
     use crate::{SourceDestError, SourceDestErrorKind};
     use std::io;
     use std::path::Path;
+
+    /// Creates a new symlink to a directory on the filesystem.
+    ///
     /// Wrapper for [std::os::windows::fs::symlink_dir](https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_dir.html)
     pub fn symlink_dir<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
         let src = src.as_ref();
@@ -11,6 +14,8 @@ pub mod fs {
             .map_err(|err| SourceDestError::build(err, SourceDestErrorKind::SymlinkDir, src, dst))
     }
 
+    /// Creates a new symlink to a non-directory file on the filesystem.
+    ///
     /// Wrapper for [std::os::windows::fs::symlink_file](https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_file.html)
     pub fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
         let src = src.as_ref();

--- a/src/path.rs
+++ b/src/path.rs
@@ -10,17 +10,30 @@ use std::path::{Path, PathBuf};
 //
 // Because no one else can implement it, we can add methods backwards-compatibly.
 pub trait PathExt: crate::Sealed {
+    /// Returns Ok(true) if the path points at an existing entity.
+    ///
     /// Wrapper for [`Path::try_exists`](https://doc.rust-lang.org/std/path/struct.Path.html#method.try_exists).
     #[cfg(rustc_1_63)]
     fn fs_err_try_exists(&self) -> io::Result<bool>;
+    /// Given a path, query the file system to get information about a file, directory, etc.
+    ///
     /// Wrapper for [`crate::metadata`].
     fn fs_err_metadata(&self) -> io::Result<fs::Metadata>;
+    /// Query the metadata about a file without following symlinks.
+    ///
     /// Wrapper for [`crate::symlink_metadata`].
     fn fs_err_symlink_metadata(&self) -> io::Result<fs::Metadata>;
+    /// Returns the canonical, absolute form of a path with all intermediate components
+    /// normalized and symbolic links resolved.
+    ///
     /// Wrapper for [`crate::canonicalize`].
     fn fs_err_canonicalize(&self) -> io::Result<PathBuf>;
+    /// Reads a symbolic link, returning the file that the link points to.
+    ///
     /// Wrapper for [`crate::read_link`].
     fn fs_err_read_link(&self) -> io::Result<PathBuf>;
+    /// Returns an iterator over the entries within a directory.
+    ///
     /// Wrapper for [`crate::read_dir`].
     fn fs_err_read_dir(&self) -> io::Result<crate::ReadDir>;
 }

--- a/src/tokio/dir_builder.rs
+++ b/src/tokio/dir_builder.rs
@@ -28,12 +28,18 @@ impl DirBuilder {
         Default::default()
     }
 
+    /// Indicates whether to create directories recursively (including all parent
+    /// directories). Parents that do not exist are created with the same security and
+    /// permissions settings.
+    ///
     /// Wrapper around [`tokio::fs::DirBuilder::recursive`].
     pub fn recursive(&mut self, recursive: bool) -> &mut Self {
         self.inner.recursive(recursive);
         self
     }
 
+    /// Creates the specified directory with the configured options.
+    ///
     /// Wrapper around [`tokio::fs::DirBuilder::create`].
     pub async fn create(&self, path: impl AsRef<Path>) -> io::Result<()> {
         let path = path.as_ref();
@@ -46,6 +52,8 @@ impl DirBuilder {
 
 #[cfg(unix)]
 impl DirBuilder {
+    /// Sets the mode to create new directories with.
+    ///
     /// Wrapper around [`tokio::fs::DirBuilder::mode`].
     pub fn mode(&mut self, mode: u32) -> &mut Self {
         self.inner.mode(mode);

--- a/src/tokio/file.rs
+++ b/src/tokio/file.rs
@@ -19,6 +19,8 @@ pub struct File {
 }
 
 impl File {
+    /// Attempts to open a file in read-only mode.
+    ///
     /// Wrapper for [`tokio::fs::File::open`].
     pub async fn open(path: impl Into<PathBuf>) -> io::Result<File> {
         let path = path.into();
@@ -28,6 +30,8 @@ impl File {
         Ok(File::from_parts(f, path))
     }
 
+    /// Opens a file in write-only mode.
+    ///
     /// Wrapper for [`tokio::fs::File::create`].
     pub async fn create(path: impl Into<PathBuf>) -> io::Result<File> {
         let path = path.into();
@@ -37,12 +41,16 @@ impl File {
         }
     }
 
+    /// Converts a [`crate::File`] to a [`tokio::fs::File`].
+    ///
     /// Wrapper for [`tokio::fs::File::from_std`].
     pub fn from_std(std: crate::File) -> File {
         let (std, path) = std.into_parts();
         File::from_parts(TokioFile::from_std(std), path)
     }
 
+    /// Attempts to sync all OS-internal metadata to disk.
+    ///
     /// Wrapper for [`tokio::fs::File::sync_all`].
     pub async fn sync_all(&self) -> io::Result<()> {
         self.tokio
@@ -51,6 +59,9 @@ impl File {
             .map_err(|err| self.error(err, ErrorKind::SyncFile))
     }
 
+    /// This function is similar to `sync_all`, except that it may not
+    /// synchronize file metadata to the filesystem.
+    ///
     /// Wrapper for [`tokio::fs::File::sync_data`].
     pub async fn sync_data(&self) -> io::Result<()> {
         self.tokio
@@ -59,6 +70,8 @@ impl File {
             .map_err(|err| self.error(err, ErrorKind::SyncFile))
     }
 
+    /// Truncates or extends the underlying file, updating the size of this file to become size.
+    ///
     /// Wrapper for [`tokio::fs::File::set_len`].
     pub async fn set_len(&self, size: u64) -> io::Result<()> {
         self.tokio
@@ -67,6 +80,8 @@ impl File {
             .map_err(|err| self.error(err, ErrorKind::SetLen))
     }
 
+    /// Queries metadata about the underlying file.
+    ///
     /// Wrapper for [`tokio::fs::File::metadata`].
     pub async fn metadata(&self) -> io::Result<Metadata> {
         self.tokio
@@ -75,6 +90,10 @@ impl File {
             .map_err(|err| self.error(err, ErrorKind::Metadata))
     }
 
+    /// Creates a new `File` instance that shares the same underlying file handle
+    /// as the existing `File` instance. Reads, writes, and seeks will affect both
+    /// `File` instances simultaneously.
+    ///
     /// Wrapper for [`tokio::fs::File::try_clone`].
     pub async fn try_clone(&self) -> io::Result<File> {
         match self.tokio.try_clone().await {
@@ -83,11 +102,16 @@ impl File {
         }
     }
 
+    /// Destructures `File` into a [`crate::File`]. This function is async to allow any
+    /// in-flight operations to complete.
+    ///
     /// Wrapper for [`tokio::fs::File::into_std`].
     pub async fn into_std(self) -> crate::File {
         crate::File::from_parts(self.tokio.into_std().await, self.path)
     }
 
+    /// Tries to immediately destructure `File` into a [`crate::File`].
+    ///
     /// Wrapper for [`tokio::fs::File::try_into_std`].
     pub fn try_into_std(self) -> Result<crate::File, File> {
         match self.tokio.try_into_std() {
@@ -96,6 +120,8 @@ impl File {
         }
     }
 
+    /// Changes the permissions on the underlying file.
+    ///
     /// Wrapper for [`tokio::fs::File::set_permissions`].
     pub async fn set_permissions(&self, perm: Permissions) -> io::Result<()> {
         self.tokio

--- a/src/tokio/mod.rs
+++ b/src/tokio/mod.rs
@@ -203,7 +203,7 @@ pub async fn symlink(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result
 /// Wrapper for [`tokio::fs::symlink_dir`].
 #[cfg(windows)]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
-pub async fn symlink(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
+pub async fn symlink_dir(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
     let (src, dst) = (src.as_ref(), dst.as_ref());
     tokio::fs::symlink_dir(src, dst)
         .await

--- a/src/tokio/mod.rs
+++ b/src/tokio/mod.rs
@@ -14,6 +14,9 @@ pub use self::read_dir::{read_dir, DirEntry, ReadDir};
 pub use dir_builder::DirBuilder;
 pub use file::File;
 
+/// Returns the canonical, absolute form of a path with all intermediate
+/// components normalized and symbolic links resolved.
+///
 /// Wrapper for [`tokio::fs::canonicalize`].
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub async fn canonicalize(path: impl AsRef<Path>) -> io::Result<PathBuf> {
@@ -23,6 +26,10 @@ pub async fn canonicalize(path: impl AsRef<Path>) -> io::Result<PathBuf> {
         .map_err(|err| Error::build(err, ErrorKind::Canonicalize, path))
 }
 
+/// Copies the contents of one file to another. This function will also copy the permission bits
+/// of the original file to the destination file.
+/// This function will overwrite the contents of to.
+///
 /// Wrapper for [`tokio::fs::copy`].
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub async fn copy(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<u64, io::Error> {
@@ -32,6 +39,8 @@ pub async fn copy(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<u64, i
         .map_err(|err| SourceDestError::build(err, SourceDestErrorKind::Copy, from, to))
 }
 
+/// Creates a new, empty directory at the provided path.
+///
 /// Wrapper for [`tokio::fs::create_dir`].
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub async fn create_dir(path: impl AsRef<Path>) -> io::Result<()> {
@@ -41,6 +50,9 @@ pub async fn create_dir(path: impl AsRef<Path>) -> io::Result<()> {
         .map_err(|err| Error::build(err, ErrorKind::CreateDir, path))
 }
 
+/// Recursively creates a directory and all of its parent components if they
+/// are missing.
+///
 /// Wrapper for [`tokio::fs::create_dir_all`].
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub async fn create_dir_all(path: impl AsRef<Path>) -> io::Result<()> {
@@ -50,6 +62,8 @@ pub async fn create_dir_all(path: impl AsRef<Path>) -> io::Result<()> {
         .map_err(|err| Error::build(err, ErrorKind::CreateDir, path))
 }
 
+/// Creates a new hard link on the filesystem.
+///
 /// Wrapper for [`tokio::fs::hard_link`].
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub async fn hard_link(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
@@ -59,6 +73,9 @@ pub async fn hard_link(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Resu
         .map_err(|err| SourceDestError::build(err, SourceDestErrorKind::HardLink, src, dst))
 }
 
+/// Given a path, queries the file system to get information about a file,
+/// directory, etc.
+///
 /// Wrapper for [`tokio::fs::metadata`].
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub async fn metadata(path: impl AsRef<Path>) -> io::Result<Metadata> {
@@ -68,6 +85,8 @@ pub async fn metadata(path: impl AsRef<Path>) -> io::Result<Metadata> {
         .map_err(|err| Error::build(err, ErrorKind::Metadata, path))
 }
 
+/// Reads the entire contents of a file into a bytes vector.
+///
 /// Wrapper for [`tokio::fs::read`].
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub async fn read(path: impl AsRef<Path>) -> io::Result<Vec<u8>> {
@@ -77,6 +96,8 @@ pub async fn read(path: impl AsRef<Path>) -> io::Result<Vec<u8>> {
         .map_err(|err| Error::build(err, ErrorKind::Read, path))
 }
 
+/// Reads a symbolic link, returning the file that the link points to.
+///
 /// Wrapper for [`tokio::fs::read_link`].
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub async fn read_link(path: impl AsRef<Path>) -> io::Result<PathBuf> {
@@ -86,6 +107,9 @@ pub async fn read_link(path: impl AsRef<Path>) -> io::Result<PathBuf> {
         .map_err(|err| Error::build(err, ErrorKind::ReadLink, path))
 }
 
+/// Creates a future which will open a file for reading and read the entire
+/// contents into a string and return said string.
+///
 /// Wrapper for [`tokio::fs::read_to_string`].
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub async fn read_to_string(path: impl AsRef<Path>) -> io::Result<String> {
@@ -95,6 +119,8 @@ pub async fn read_to_string(path: impl AsRef<Path>) -> io::Result<String> {
         .map_err(|err| Error::build(err, ErrorKind::Read, path))
 }
 
+/// Removes an existing, empty directory.
+///
 /// Wrapper for [`tokio::fs::remove_dir`].
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub async fn remove_dir(path: impl AsRef<Path>) -> io::Result<()> {
@@ -104,6 +130,8 @@ pub async fn remove_dir(path: impl AsRef<Path>) -> io::Result<()> {
         .map_err(|err| Error::build(err, ErrorKind::RemoveDir, path))
 }
 
+/// Removes a directory at this path, after removing all its contents. Use carefully!
+///
 /// Wrapper for [`tokio::fs::remove_dir_all`].
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub async fn remove_dir_all(path: impl AsRef<Path>) -> io::Result<()> {
@@ -113,6 +141,8 @@ pub async fn remove_dir_all(path: impl AsRef<Path>) -> io::Result<()> {
         .map_err(|err| Error::build(err, ErrorKind::RemoveDir, path))
 }
 
+/// Removes a file from the filesystem.
+///
 /// Wrapper for [`tokio::fs::remove_file`].
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub async fn remove_file(path: impl AsRef<Path>) -> io::Result<()> {
@@ -122,6 +152,9 @@ pub async fn remove_file(path: impl AsRef<Path>) -> io::Result<()> {
         .map_err(|err| Error::build(err, ErrorKind::RemoveFile, path))
 }
 
+/// Renames a file or directory to a new name, replacing the original file if
+/// `to` already exists.
+///
 /// Wrapper for [`tokio::fs::rename`].
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub async fn rename(from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Result<()> {
@@ -131,6 +164,8 @@ pub async fn rename(from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Result<
         .map_err(|err| SourceDestError::build(err, SourceDestErrorKind::Rename, from, to))
 }
 
+/// Changes the permissions found on a file or a directory.
+///
 /// Wrapper for [`tokio::fs::set_permissions`].
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub async fn set_permissions(path: impl AsRef<Path>, perm: Permissions) -> io::Result<()> {
@@ -140,6 +175,8 @@ pub async fn set_permissions(path: impl AsRef<Path>, perm: Permissions) -> io::R
         .map_err(|err| Error::build(err, ErrorKind::SetPermissions, path))
 }
 
+/// Queries the file system metadata for a path.
+///
 /// Wrapper for [`tokio::fs::symlink_metadata`].
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub async fn symlink_metadata(path: impl AsRef<Path>) -> io::Result<Metadata> {
@@ -149,6 +186,8 @@ pub async fn symlink_metadata(path: impl AsRef<Path>) -> io::Result<Metadata> {
         .map_err(|err| Error::build(err, ErrorKind::SymlinkMetadata, path))
 }
 
+/// Creates a new symbolic link on the filesystem.
+///
 /// Wrapper for [`tokio::fs::symlink`].
 #[cfg(unix)]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
@@ -159,6 +198,8 @@ pub async fn symlink(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result
         .map_err(|err| SourceDestError::build(err, SourceDestErrorKind::Symlink, src, dst))
 }
 
+/// Creates a new directory symlink on the filesystem.
+///
 /// Wrapper for [`tokio::fs::symlink_dir`].
 #[cfg(windows)]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
@@ -169,6 +210,8 @@ pub async fn symlink(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result
         .map_err(|err| SourceDestError::build(err, SourceDestErrorKind::SymlinkDir, src, dst))
 }
 
+/// Creates a new file symbolic link on the filesystem.
+///
 /// Wrapper for [`tokio::fs::symlink_file`].
 #[cfg(windows)]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
@@ -179,6 +222,9 @@ pub async fn symlink_file(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::R
         .map_err(|err| SourceDestError::build(err, SourceDestErrorKind::SymlinkFile, src, dst))
 }
 
+/// Creates a future that will open a file for writing and write the entire
+/// contents of `contents` to it.
+///
 /// Wrapper for [`tokio::fs::write`].
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub async fn write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> io::Result<()> {

--- a/src/tokio/mod.rs
+++ b/src/tokio/mod.rs
@@ -203,6 +203,16 @@ pub async fn symlink(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result
 /// Wrapper for [`tokio::fs::symlink_dir`].
 #[cfg(windows)]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
+#[deprecated = "use fs_err::tokio::symlink_dir instead"]
+pub async fn symlink(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
+    symlink_dir(src, dst).await
+}
+
+/// Creates a new directory symlink on the filesystem.
+///
+/// Wrapper for [`tokio::fs::symlink_dir`].
+#[cfg(windows)]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub async fn symlink_dir(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
     let (src, dst) = (src.as_ref(), dst.as_ref());
     tokio::fs::symlink_dir(src, dst)

--- a/src/tokio/open_options.rs
+++ b/src/tokio/open_options.rs
@@ -34,42 +34,56 @@ impl OpenOptions {
         }
     }
 
+    /// Sets the option for read access.
+    ///
     /// Wrapper for [`tokio::fs::OpenOptions::read`].
     pub fn read(&mut self, read: bool) -> &mut OpenOptions {
         self.tokio.read(read);
         self
     }
 
+    /// Sets the option for write access.
+    ///
     /// Wrapper for [`tokio::fs::OpenOptions::write`].
     pub fn write(&mut self, write: bool) -> &mut OpenOptions {
         self.tokio.write(write);
         self
     }
 
+    /// Sets the option for the append mode.
+    ///
     /// Wrapper for [`tokio::fs::OpenOptions::append`].
     pub fn append(&mut self, append: bool) -> &mut OpenOptions {
         self.tokio.append(append);
         self
     }
 
+    /// Sets the option for truncating a previous file.
+    ///
     /// Wrapper for [`tokio::fs::OpenOptions::truncate`].
     pub fn truncate(&mut self, truncate: bool) -> &mut OpenOptions {
         self.tokio.truncate(truncate);
         self
     }
 
+    /// Sets the option for creating a new file.
+    ///
     /// Wrapper for [`tokio::fs::OpenOptions::create`].
     pub fn create(&mut self, create: bool) -> &mut OpenOptions {
         self.tokio.create(create);
         self
     }
 
+    /// Sets the option to always create a new file.
+    ///
     /// Wrapper for [`tokio::fs::OpenOptions::create_new`].
     pub fn create_new(&mut self, create_new: bool) -> &mut OpenOptions {
         self.tokio.create_new(create_new);
         self
     }
 
+    /// Opens a file at `path` with the options specified by `self`.
+    ///
     /// Wrapper for [`tokio::fs::OpenOptions::open`].
     pub async fn open(&self, path: impl AsRef<Path>) -> io::Result<File> {
         let path = path.as_ref();
@@ -83,12 +97,16 @@ impl OpenOptions {
 
 #[cfg(unix)]
 impl OpenOptions {
+    /// Sets the mode bits that a new file will be created with.
+    ///
     /// Wrapper for [`tokio::fs::OpenOptions::mode`].
     pub fn mode(&mut self, mode: u32) -> &mut OpenOptions {
         self.tokio.mode(mode);
         self
     }
 
+    /// Passes custom flags to the `flags` argument of `open`.
+    ///
     /// Wrapper for [`tokio::fs::OpenOptions::custom_flags`].
     pub fn custom_flags(&mut self, flags: i32) -> &mut OpenOptions {
         self.tokio.custom_flags(flags);

--- a/src/tokio/read_dir.rs
+++ b/src/tokio/read_dir.rs
@@ -6,6 +6,8 @@ use std::path::{Path, PathBuf};
 use std::task::{ready, Context, Poll};
 use tokio::fs;
 
+/// Returns a stream over the entries within a directory.
+///
 /// Wrapper for [`tokio::fs::read_dir`].
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub async fn read_dir(path: impl AsRef<Path>) -> io::Result<ReadDir> {
@@ -31,6 +33,8 @@ pub struct ReadDir {
 }
 
 impl ReadDir {
+    /// Returns the next entry in the directory stream.
+    ///
     /// Wrapper around [`tokio::fs::ReadDir::next_entry`].
     pub async fn next_entry(&mut self) -> io::Result<Option<DirEntry>> {
         match self.tokio.next_entry().await {
@@ -39,6 +43,8 @@ impl ReadDir {
         }
     }
 
+    /// Polls for the next directory entry in the stream.
+    ///
     /// Wrapper around [`tokio::fs::ReadDir::poll_next_entry`].
     pub fn poll_next_entry(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<Option<DirEntry>>> {
         Poll::Ready(match ready!(self.tokio.poll_next_entry(cx)) {
@@ -58,16 +64,23 @@ pub struct DirEntry {
 }
 
 impl DirEntry {
+    /// Returns the full path to the file that this entry represents.
+    ///
     /// Wrapper around [`tokio::fs::DirEntry::path`].
     pub fn path(&self) -> PathBuf {
         self.tokio.path()
     }
 
+    /// Returns the bare file name of this directory entry without any other
+    /// leading path component.
+    ///
     /// Wrapper around [`tokio::fs::DirEntry::file_name`].
     pub fn file_name(&self) -> OsString {
         self.tokio.file_name()
     }
 
+    /// Returns the metadata for the file that this entry points at.
+    ///
     /// Wrapper around [`tokio::fs::DirEntry::metadata`].
     pub async fn metadata(&self) -> io::Result<Metadata> {
         self.tokio
@@ -76,6 +89,8 @@ impl DirEntry {
             .map_err(|err| Error::build(err, ErrorKind::Metadata, self.path()))
     }
 
+    /// Returns the file type for the file that this entry points at.
+    ///
     /// Wrapper around [`tokio::fs::DirEntry::file_type`].
     pub async fn file_type(&self) -> io::Result<FileType> {
         self.tokio
@@ -87,6 +102,8 @@ impl DirEntry {
 
 #[cfg(unix)]
 impl DirEntry {
+    /// Returns the underlying `d_ino` field in the contained `dirent` structure.
+    ///
     /// Wrapper around [`tokio::fs::DirEntry::ino`].
     pub fn ino(&self) -> u64 {
         self.tokio.ino()


### PR DESCRIPTION
This implements #45.

While working on it I noticed that the wrapper for the Windows-specific `tokio::fs::symlink_dir()` appears misnamed as `fs_err::tokio::symlink()` (instead of the expected `fs_err::tokio::symlink_dir()`), so I fixed that as well - but in a separate commit.