### PR TITLE
Fix typo

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -88,7 +88,7 @@ impl fmt::Display for Error {
             E::SymlinkMetadata => {
                 write!(formatter, "failed to query metadata of symlink `{}`", path)
             }
-            E::FileExists => write!(formatter, "failed to check file existance `{}`", path),
+            E::FileExists => write!(formatter, "failed to check file existence `{}`", path),
 
             #[cfg(windows)]
             E::SeekRead => write!(formatter, "failed to seek and read from `{}`", path),


### PR DESCRIPTION
The typo itself is boring, but how I found it was fun ;)

```
I: atuin: spelling-error-in-binary conection connection [usr/bin/atuin]
N:
N:   Lintian found a spelling error in the given binary. Lintian has a list of
N:   common misspellings that it looks for. It does not have a dictionary like
N:   a spelling checker does.
N:
N:   If the string containing the spelling error is translated with the help of
N:   gettext or a similar tool, please fix the error in the translations as
N:   well as the English text to avoid making the translations fuzzy. With
N:   gettext, for example, this means you should also fix the spelling mistake
N:   in the corresponding msgids in the *.po files.
N:
N:   You can often find the word in the source code by running:
N:
N:    grep -rw <word> <source-tree>
N:
N:   This tag may produce false positives for words that contain non-ASCII
N:   characters due to limitations in strings.
N:
N:   Visibility: info
N:   Show-Always: no
N:   Check: binaries/spelling
N:
N:
I: atuin: spelling-error-in-binary existance existence [usr/bin/atuin]
```