### PR TITLE
Remove deprecation warning:

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 exclude = [".github", ".gitignore", "README.tpl"]
 
 [dependencies]
-tokio = { version = "1.21", optional = true, default_features = false, features = ["fs"] }
+tokio = { version = "1.21", optional = true, default-features = false, features = ["fs"] }
 
 [build-dependencies]
 autocfg = "1"


### PR DESCRIPTION
```
warning: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
(in the `tokio` dependency)
    Checking itoa v1.0.9
    Checking serde v1.0.192
   Compiling fs-err v2.11.0 (/home/runner/work/fs-err/fs-err)
    Checking ryu v1.0.15
    Checking serde_json v1.0.100
```