### PR TITLE
Add async-fs wrappers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "async-channel"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,6 +85,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "cc"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,12 +110,81 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "event-listener"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fs-err"
 version = "3.1.0"
 dependencies = [
+ "async-fs",
  "autocfg",
+ "futures-lite",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -102,10 +230,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ readme = "README.md"
 exclude = [".github", ".gitignore", "README.tpl"]
 
 [dependencies]
+async-fs = { version = "2.1.2", optional = true }
+futures-lite = { version = "2.6.0", optional = true }
 tokio = { version = "1.21", optional = true, default-features = false, features = ["fs"] }
 
 [build-dependencies]
@@ -27,6 +29,7 @@ serde_json = "1.0.64"
 # no longer include the original `std::io::Error` source in the `Display` implementation.
 # This is useful if errors are wrapped in another library such as Anyhow.
 expose_original_error = []
+async-fs = ["dep:async-fs", "dep:futures-lite"]
 
 [package.metadata.release]
 tag-name = "{{version}}"

--- a/src/async_fs/dir_builder.rs
+++ b/src/async_fs/dir_builder.rs
@@ -1,0 +1,53 @@
+#[cfg(unix)]
+use crate::async_fs::unix;
+use crate::errors::{Error, ErrorKind};
+use crate::private::Sealed;
+#[cfg(unix)]
+use async_fs::unix::DirBuilderExt;
+use std::io;
+use std::path::Path;
+
+/// A builder for creating directories with configurable options.
+///
+/// This is a wrapper around [`async_fs::DirBuilder`].
+#[derive(Debug, Default)]
+#[cfg_attr(docsrs, doc(cfg(feature = "async-fs")))]
+pub struct DirBuilder(async_fs::DirBuilder);
+
+impl DirBuilder {
+    /// Creates a blank set of options.
+    ///
+    /// This is a wrapper around [`async_fs::DirBuilder::new`].
+    pub fn new() -> Self {
+        Self(async_fs::DirBuilder::new())
+    }
+
+    /// Sets the option for recursive mode.
+    ///
+    /// This is a wrapper around [`async_fs::DirBuilder::recursive`].
+    pub fn recursive(&mut self, recursive: bool) -> &mut Self {
+        self.0.recursive(recursive);
+        self
+    }
+
+    /// Creates a directory with the configured options.
+    ///
+    /// This is a wrapper around [`async_fs::DirBuilder::create`].
+    pub async fn create<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
+        let path = path.as_ref();
+        self.0
+            .create(path)
+            .await
+            .map_err(|err| Error::build(err, ErrorKind::CreateDir, path))
+    }
+}
+
+impl Sealed for DirBuilder {}
+
+#[cfg(unix)]
+impl unix::DirBuilderExt for DirBuilder {
+    fn mode(&mut self, mode: u32) -> &mut Self {
+        self.0.mode(mode);
+        self
+    }
+}

--- a/src/async_fs/file.rs
+++ b/src/async_fs/file.rs
@@ -1,0 +1,225 @@
+use crate::errors::{Error, ErrorKind};
+use async_fs::File as AsyncFsFile;
+use futures_lite::{AsyncRead, AsyncSeek, AsyncWrite};
+use std::fs::{Metadata, Permissions};
+use std::io;
+use std::io::SeekFrom;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::task::{ready, Context, Poll};
+
+/// Wrapper around [`async_fs::File`] which adds more helpful
+/// information to all errors.
+#[derive(Debug)]
+#[cfg_attr(docsrs, doc(cfg(feature = "async-fs")))]
+pub struct File {
+    async_fs: async_fs::File,
+    path: PathBuf,
+}
+
+impl File {
+    /// Opens a file in read-only mode.
+    ///
+    /// This is a wrapper around [`async_fs::File::open`].
+    pub async fn open<P: AsRef<Path>>(path: P) -> io::Result<File> {
+        let path = path.as_ref();
+        let f = AsyncFsFile::open(path)
+            .await
+            .map_err(|err| Error::build(err, ErrorKind::OpenFile, &path))?;
+        Ok(File::from_parts(f, path))
+    }
+
+    /// Opens a file in write-only mode.
+    ///
+    /// This is a wrapper around [`async_fs::File::create`].
+    pub async fn create<P: AsRef<Path>>(path: P) -> io::Result<File> {
+        let path = path.as_ref();
+        match AsyncFsFile::create(&path).await {
+            Ok(f) => Ok(File::from_parts(f, path)),
+            Err(err) => Err(Error::build(err, ErrorKind::CreateFile, &path)),
+        }
+    }
+
+    /// Synchronizes OS-internal buffered contents and metadata to disk.
+    ///
+    /// This is a wrapper around [`async_fs::File::sync_all`].
+    pub async fn sync_all(&self) -> io::Result<()> {
+        self.async_fs
+            .sync_all()
+            .await
+            .map_err(|err| Error::build(err, ErrorKind::SyncFile, &self.path))
+    }
+
+    /// Synchronizes OS-internal buffered contents to disk.
+    ///
+    /// This is a wrapper around [`async_fs::File::sync_data`].
+    pub async fn sync_data(&self) -> io::Result<()> {
+        self.async_fs
+            .sync_data()
+            .await
+            .map_err(|err| Error::build(err, ErrorKind::SyncFile, &self.path))
+    }
+
+    /// Truncates or extends the file.
+    ///
+    /// This is a wrapper around [`async_fs::File::set_len`].
+    pub async fn set_len(&self, size: u64) -> io::Result<()> {
+        self.async_fs
+            .set_len(size)
+            .await
+            .map_err(|err| Error::build(err, ErrorKind::SetLen, &self.path))
+    }
+
+    /// Reads the file's metadata.
+    ///
+    /// This is a wrapper around [`async_fs::File::metadata`].
+    pub async fn metadata(&self) -> io::Result<Metadata> {
+        self.async_fs
+            .metadata()
+            .await
+            .map_err(|err| Error::build(err, ErrorKind::Metadata, &self.path))
+    }
+
+    /// Changes the permissions on the file.
+    ///
+    /// This is a wrapper around [`async_fs::File::set_permissions`].
+    pub async fn set_permissions(&self, perm: Permissions) -> io::Result<()> {
+        self.async_fs
+            .set_permissions(perm)
+            .await
+            .map_err(|err| Error::build(err, ErrorKind::SetPermissions, &self.path))
+    }
+}
+
+/// Methods added by fs-err that are not available on
+/// [`async_fs::File`].
+impl File {
+    /// Creates a [`File`](struct.File.html) from a raw file and its path.
+    pub fn from_parts<P>(file: AsyncFsFile, path: P) -> Self
+    where
+        P: Into<PathBuf>,
+    {
+        File {
+            async_fs: file,
+            path: path.into(),
+        }
+    }
+
+    /// Extract the raw file and its path from this [`File`](struct.File.html).
+    pub fn into_parts(self) -> (AsyncFsFile, PathBuf) {
+        (self.async_fs, self.path)
+    }
+
+    /// Returns a reference to the underlying [`async_fs::File`].
+    pub fn file(&self) -> &AsyncFsFile {
+        &self.async_fs
+    }
+
+    /// Returns a mutable reference to the underlying [`async_fs::File`].
+    pub fn file_mut(&mut self) -> &mut AsyncFsFile {
+        &mut self.async_fs
+    }
+
+    /// Returns a reference to the path that this file was created with.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Wrap the error in information specific to this `File` object.
+    fn error(&self, source: io::Error, kind: ErrorKind) -> io::Error {
+        Error::build(source, kind, &self.path)
+    }
+}
+
+impl From<crate::File> for File {
+    fn from(inner: crate::File) -> File {
+        let (std, path) = inner.into_parts();
+        File::from_parts(std.into(), path)
+    }
+}
+
+impl From<File> for AsyncFsFile {
+    fn from(f: File) -> Self {
+        f.into_parts().0
+    }
+}
+
+#[cfg(unix)]
+impl std::os::unix::io::AsRawFd for File {
+    fn as_raw_fd(&self) -> std::os::unix::io::RawFd {
+        self.async_fs.as_raw_fd()
+    }
+}
+
+#[cfg(windows)]
+impl std::os::windows::io::AsRawHandle for File {
+    fn as_raw_handle(&self) -> std::os::windows::io::RawHandle {
+        self.async_fs.as_raw_handle()
+    }
+}
+
+#[cfg(unix)]
+impl std::os::unix::io::AsFd for File {
+    fn as_fd(&self) -> std::os::unix::io::BorrowedFd<'_> {
+        self.async_fs.as_fd()
+    }
+}
+
+#[cfg(windows)]
+impl std::os::windows::io::AsHandle for File {
+    fn as_handle(&self) -> std::os::windows::io::BorrowedHandle<'_> {
+        self.async_fs.as_handle()
+    }
+}
+
+impl AsyncRead for File {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        Poll::Ready(
+            ready!(Pin::new(&mut self.async_fs).poll_read(cx, buf))
+                .map_err(|err| self.error(err, ErrorKind::Read)),
+        )
+    }
+}
+
+impl AsyncWrite for File {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Poll::Ready(
+            ready!(Pin::new(&mut self.async_fs).poll_write(cx, buf))
+                .map_err(|err| self.error(err, ErrorKind::Write)),
+        )
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(
+            ready!(Pin::new(&mut self.async_fs).poll_flush(cx))
+                .map_err(|err| self.error(err, ErrorKind::Flush)),
+        )
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(
+            ready!(Pin::new(&mut self.async_fs).poll_close(cx))
+                .map_err(|err| self.error(err, ErrorKind::Flush)),
+        )
+    }
+}
+
+impl AsyncSeek for File {
+    fn poll_seek(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        pos: SeekFrom,
+    ) -> Poll<io::Result<u64>> {
+        Pin::new(&mut self.async_fs)
+            .poll_seek(cx, pos)
+            .map_err(|err| self.error(err, ErrorKind::Seek))
+    }
+}

--- a/src/async_fs/mod.rs
+++ b/src/async_fs/mod.rs
@@ -1,0 +1,182 @@
+//! async-fs-specific wrappers that use `fs_err` error messages.
+
+mod dir_builder;
+mod file;
+mod open_options;
+mod read_dir;
+#[cfg(unix)]
+pub mod unix;
+#[cfg(windows)]
+pub mod windows;
+
+use crate::errors::{Error, ErrorKind, SourceDestError, SourceDestErrorKind};
+#[doc(no_inline)]
+pub use std::fs::{FileType, Metadata, Permissions};
+use std::io;
+use std::path::{Path, PathBuf};
+
+pub use self::open_options::OpenOptions;
+pub use self::read_dir::{read_dir, DirEntry, ReadDir};
+pub use dir_builder::DirBuilder;
+pub use file::File;
+
+/// Returns the canonical form of a path.
+///
+/// Wrapper for [`async_fs::canonicalize`].
+pub async fn canonicalize<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
+    let path = path.as_ref();
+    async_fs::canonicalize(path)
+        .await
+        .map_err(|err| Error::build(err, ErrorKind::Canonicalize, path))
+}
+
+/// Copies a file to a new location.
+///
+/// Wrapper for [`async_fs::copy`].
+pub async fn copy<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<u64> {
+    let (src, dst) = (src.as_ref(), dst.as_ref());
+    async_fs::copy(src, dst)
+        .await
+        .map_err(|err| SourceDestError::build(err, SourceDestErrorKind::Copy, src, dst))
+}
+
+/// Creates a new, empty directory at the provided path
+///
+/// Wrapper for [`async_fs::create_dir`].
+pub async fn create_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
+    let path = path.as_ref();
+    async_fs::create_dir(path)
+        .await
+        .map_err(|err| Error::build(err, ErrorKind::CreateDir, path))
+}
+
+/// Recursively create a directory and all of its parent components if they
+/// are missing.
+///
+/// Wrapper for [`async_fs::create_dir_all`].
+pub async fn create_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
+    let path = path.as_ref();
+    async_fs::create_dir_all(path)
+        .await
+        .map_err(|err| Error::build(err, ErrorKind::CreateDir, path))
+}
+
+/// Creates a hard link on the filesystem.
+///
+/// Wrapper for [`async_fs::hard_link`].
+pub async fn hard_link<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
+    let (src, dst) = (src.as_ref(), dst.as_ref());
+    async_fs::hard_link(src, dst)
+        .await
+        .map_err(|err| SourceDestError::build(err, SourceDestErrorKind::HardLink, src, dst))
+}
+
+/// Reads metadata for a path.
+///
+/// Wrapper for [`async_fs::metadata`].
+pub async fn metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
+    let path = path.as_ref();
+    async_fs::metadata(path)
+        .await
+        .map_err(|err| Error::build(err, ErrorKind::Metadata, path))
+}
+
+/// Reads the entire contents of a file as raw bytes.
+///
+/// Wrapper for [`async_fs::read`].
+pub async fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
+    let path = path.as_ref();
+    async_fs::read(path)
+        .await
+        .map_err(|err| Error::build(err, ErrorKind::Read, path))
+}
+
+/// Reads a symbolic link and returns the path it points to.
+///
+/// Wrapper for [`async_fs::read_link`].
+pub async fn read_link<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
+    let path = path.as_ref();
+    async_fs::read_link(path)
+        .await
+        .map_err(|err| Error::build(err, ErrorKind::ReadLink, path))
+}
+
+/// Reads the entire contents of a file as a string.
+///
+/// Wrapper for [`async_fs::read_to_string`].
+pub async fn read_to_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
+    let path = path.as_ref();
+    async_fs::read_to_string(path)
+        .await
+        .map_err(|err| Error::build(err, ErrorKind::Read, path))
+}
+
+/// Removes an empty directory.
+///
+/// Wrapper for [`async_fs::remove_dir`].
+pub async fn remove_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
+    let path = path.as_ref();
+    async_fs::remove_dir(path)
+        .await
+        .map_err(|err| Error::build(err, ErrorKind::RemoveDir, path))
+}
+
+/// Removes a directory and all of its contents.
+///
+/// Wrapper for [`async_fs::remove_dir_all`].
+pub async fn remove_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
+    let path = path.as_ref();
+    async_fs::remove_dir_all(path)
+        .await
+        .map_err(|err| Error::build(err, ErrorKind::RemoveDir, path))
+}
+
+/// Removes a file.
+///
+/// Wrapper for [`async_fs::remove_file`].
+pub async fn remove_file<P: AsRef<Path>>(path: P) -> io::Result<()> {
+    let path = path.as_ref();
+    async_fs::remove_file(path)
+        .await
+        .map_err(|err| Error::build(err, ErrorKind::RemoveFile, path))
+}
+
+/// Renames a file or directory to a new location.
+///
+/// Wrapper for [`async_fs::rename`].
+pub async fn rename<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
+    let (src, dst) = (src.as_ref(), dst.as_ref());
+    async_fs::rename(src, dst)
+        .await
+        .map_err(|err| SourceDestError::build(err, SourceDestErrorKind::Rename, src, dst))
+}
+
+/// Changes the permissions of a file or directory.
+///
+/// Wrapper for [`async_fs::set_permissions`].
+pub async fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result<()> {
+    let path = path.as_ref();
+    async_fs::set_permissions(path, perm)
+        .await
+        .map_err(|err| Error::build(err, ErrorKind::SetPermissions, path))
+}
+
+/// Reads metadata for a path without following symbolic links.
+///
+/// Wrapper for [`async_fs::symlink_metadata`].
+pub async fn symlink_metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
+    let path = path.as_ref();
+    async_fs::symlink_metadata(path)
+        .await
+        .map_err(|err| Error::build(err, ErrorKind::SymlinkMetadata, path))
+}
+
+/// Writes a slice of bytes as the new contents of a file.
+///
+/// Wrapper for [`async_fs::write`].
+pub async fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result<()> {
+    let (path, contents) = (path.as_ref(), contents.as_ref());
+    async_fs::write(path, contents)
+        .await
+        .map_err(|err| Error::build(err, ErrorKind::Write, path))
+}

--- a/src/async_fs/open_options.rs
+++ b/src/async_fs/open_options.rs
@@ -1,0 +1,135 @@
+use crate::async_fs::file::File;
+use crate::errors::{Error, ErrorKind};
+use crate::private::Sealed;
+#[cfg(unix)]
+use async_fs::unix::OpenOptionsExt;
+#[cfg(windows)]
+use async_fs::windows::OpenOptionsExt;
+use std::io;
+use std::path::Path;
+
+/// A builder for opening files with configurable options.
+///
+/// This is a wrapper around [`async_fs::OpenOptions`].
+#[derive(Clone, Debug)]
+pub struct OpenOptions(async_fs::OpenOptions);
+
+impl OpenOptions {
+    /// Creates a blank set of options.
+    ///
+    /// This is a wrapper around [`async_fs::OpenOptions::new`].
+    pub fn new() -> OpenOptions {
+        OpenOptions(async_fs::OpenOptions::new())
+    }
+
+    /// Configures the option for read mode.
+    ///
+    /// This is a wrapper around [`async_fs::OpenOptions::read`].
+    pub fn read(&mut self, read: bool) -> &mut OpenOptions {
+        self.0.read(read);
+        self
+    }
+
+    /// Configures the option for write mode.
+    ///
+    /// This is a wrapper around [`async_fs::OpenOptions::write`].
+    pub fn write(&mut self, write: bool) -> &mut OpenOptions {
+        self.0.write(write);
+        self
+    }
+
+    /// Configures the option for append mode.
+    ///
+    /// This is a wrapper around [`async_fs::OpenOptions::append`].
+    pub fn append(&mut self, append: bool) -> &mut OpenOptions {
+        self.0.append(append);
+        self
+    }
+
+    /// Configures the option for truncating the previous file.
+    ///
+    /// This is a wrapper around [`async_fs::OpenOptions::truncate`].
+    pub fn truncate(&mut self, truncate: bool) -> &mut OpenOptions {
+        self.0.truncate(truncate);
+        self
+    }
+
+    /// Configures the option for creating a new file if it doesn't exist.
+    ///
+    /// This is a wrapper around [`async_fs::OpenOptions::create`].
+    pub fn create(&mut self, create: bool) -> &mut OpenOptions {
+        self.0.create(create);
+        self
+    }
+
+    /// Configures the option for creating a new file or failing if it already exists.
+    ///
+    /// This is a wrapper around [`async_fs::OpenOptions::create_new`].
+    pub fn create_new(&mut self, create_new: bool) -> &mut OpenOptions {
+        self.0.create_new(create_new);
+        self
+    }
+
+    /// Opens a file with the configured options.
+    ///
+    /// This is a wrapper around [`async_fs::OpenOptions::open`].
+    pub async fn open<P: AsRef<Path>>(&self, path: P) -> io::Result<File> {
+        let path = path.as_ref();
+        Ok(File::from_parts(
+            self.0
+                .open(path)
+                .await
+                .map_err(|err| Error::build(err, ErrorKind::OpenFile, path))?,
+            path,
+        ))
+    }
+}
+
+impl Default for OpenOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Sealed for OpenOptions {}
+
+#[cfg(unix)]
+impl crate::os::unix::fs::OpenOptionsExt for OpenOptions {
+    fn mode(&mut self, mode: u32) -> &mut Self {
+        self.0.mode(mode);
+        self
+    }
+
+    fn custom_flags(&mut self, flags: i32) -> &mut Self {
+        self.0.custom_flags(flags);
+        self
+    }
+}
+
+#[cfg(windows)]
+impl crate::os::windows::fs::OpenOptionsExt for OpenOptions {
+    fn access_mode(&mut self, access: u32) -> &mut Self {
+        self.0.access_mode(access);
+        self
+    }
+
+    fn share_mode(&mut self, val: u32) -> &mut Self {
+        self.0.share_mode(val);
+        self
+    }
+
+    fn custom_flags(&mut self, flags: u32) -> &mut Self {
+        self.0.custom_flags(flags);
+        self
+    }
+
+    fn attributes(&mut self, val: u32) -> &mut Self {
+        self.0.attributes(val);
+        self
+    }
+
+    fn security_qos_flags(&mut self, flags: u32) -> &mut Self {
+        self.0.security_qos_flags(flags);
+        self
+    }
+}

--- a/src/async_fs/read_dir.rs
+++ b/src/async_fs/read_dir.rs
@@ -1,0 +1,105 @@
+use crate::errors::{Error, ErrorKind};
+use crate::private::Sealed;
+use futures_lite::StreamExt;
+
+use futures_lite::Stream;
+use std::ffi::OsString;
+use std::fs::{FileType, Metadata};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::task::{ready, Context, Poll};
+
+#[cfg(unix)]
+use async_fs::unix::DirEntryExt as _;
+
+/// Returns a stream of entries in a directory.
+///
+/// Wrapper for [`async_fs::read_dir`].
+pub async fn read_dir<P: AsRef<Path>>(path: P) -> io::Result<ReadDir> {
+    let path = path.as_ref();
+    let async_fs = async_fs::read_dir(path)
+        .await
+        .map_err(|err| Error::build(err, ErrorKind::ReadDir, path))?;
+    Ok(ReadDir {
+        async_fs,
+        path: path.to_owned(),
+    })
+}
+
+/// Reads the entries in a directory.
+///
+/// This is a wrapper around [`async_fs::ReadDir`].
+#[derive(Debug)]
+#[must_use = "streams do nothing unless polled"]
+#[cfg_attr(docsrs, doc(cfg(feature = "async_fs")))]
+pub struct ReadDir {
+    async_fs: async_fs::ReadDir,
+    path: PathBuf,
+}
+
+impl Stream for ReadDir {
+    type Item = io::Result<DirEntry>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Poll::Ready(match ready!(self.async_fs.poll_next(cx)) {
+            Some(Ok(entry)) => Some(Ok(DirEntry(entry))),
+            Some(Err(err)) => Some(Err(Error::build(err, ErrorKind::ReadDir, &self.path))),
+            None => None,
+        })
+    }
+}
+
+/// An entry in a directory.
+///
+/// This is a wrapper around [`async_fs::DirEntry`].
+#[derive(Debug, Clone)]
+pub struct DirEntry(async_fs::DirEntry);
+
+impl DirEntry {
+    /// Returns the full path to this entry.
+    ///
+    /// This is a wrapper around [`async_fs::DirEntry::path`].
+    pub fn path(&self) -> PathBuf {
+        self.0.path()
+    }
+
+    /// Reads the metadata for this entry.
+    ///
+    /// This is a wrapper around [`async_fs::DirEntry::metadata`].
+    pub async fn metadata(&self) -> io::Result<Metadata> {
+        self.0
+            .metadata()
+            .await
+            .map_err(|err| Error::build(err, ErrorKind::Metadata, self.path()))
+    }
+
+    /// Reads the file type for this entry.
+    ///
+    /// This is a wrapper around [`async_fs::DirEntry::file_type`].
+    pub async fn file_type(&self) -> io::Result<FileType> {
+        self.0
+            .file_type()
+            .await
+            .map_err(|err| Error::build(err, ErrorKind::Metadata, self.path()))
+    }
+
+    /// Returns the bare name of this entry without the leading path.
+    ///
+    /// This is a wrapper around [`async_fs::DirEntry::file_name`].
+    pub fn file_name(&self) -> OsString {
+        self.0.file_name()
+    }
+}
+
+impl Sealed for DirEntry {}
+
+#[cfg(unix)]
+impl crate::os::unix::fs::DirEntryExt for DirEntry {
+    /// Returns the underlying `d_ino` field in the contained `dirent` structure.
+    ///
+    /// This is a wrapper around [`async_fs::unix::DirEntryExt::ino`]
+    fn ino(&self) -> u64 {
+        self.0.ino()
+    }
+}

--- a/src/async_fs/unix.rs
+++ b/src/async_fs/unix.rs
@@ -1,0 +1,26 @@
+//! Unix-specific extensions.
+
+use crate::errors::{SourceDestError, SourceDestErrorKind};
+use crate::private::Sealed;
+use std::io;
+#[doc(no_inline)]
+pub use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
+use std::path::Path;
+
+/// Creates a new symbolic link on the filesystem.
+///
+/// Wrapper for [`async_fs::unix::symlink`].
+pub async fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
+    let (src, dst) = (src.as_ref(), dst.as_ref());
+    async_fs::unix::symlink(src, dst)
+        .await
+        .map_err(|err| SourceDestError::build(err, SourceDestErrorKind::Symlink, src, dst))
+}
+
+/// Unix-specific extensions to [`DirBuilder`].
+pub trait DirBuilderExt: Sealed {
+    /// Sets the mode to create new directories with.
+    ///
+    /// Wrapper for [`async_fs::unix::DirBuilderExt::mode`]
+    fn mode(&mut self, mode: u32) -> &mut Self;
+}

--- a/src/async_fs/unix.rs
+++ b/src/async_fs/unix.rs
@@ -17,7 +17,7 @@ pub async fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Resu
         .map_err(|err| SourceDestError::build(err, SourceDestErrorKind::Symlink, src, dst))
 }
 
-/// Unix-specific extensions to [`DirBuilder`].
+/// Unix-specific extensions to [`crate::async_fs::DirBuilder`].
 pub trait DirBuilderExt: Sealed {
     /// Sets the mode to create new directories with.
     ///

--- a/src/async_fs/windows.rs
+++ b/src/async_fs/windows.rs
@@ -1,0 +1,25 @@
+//! Windows-specific extensions.
+
+use crate::errors::{SourceDestError, SourceDestErrorKind};
+use std::io;
+use std::path::Path;
+
+/// Creates a new file symbolic link on the filesystem.
+///
+/// Wrapper for [`async_fs::windows::symlink_dir`].
+pub async fn symlink_dir<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
+    let (src, dst) = (src.as_ref(), dst.as_ref());
+    async_fs::windows::symlink_dir(src, dst)
+        .await
+        .map_err(|err| SourceDestError::build(err, SourceDestErrorKind::SymlinkDir, src, dst))
+}
+
+/// Creates a new file symbolic link on the filesystem.
+///
+/// Wrapper for [`async_fs::windows::symlink_file`].
+pub async fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
+    let (src, dst) = (src.as_ref(), dst.as_ref());
+    async_fs::windows::symlink_file(src, dst)
+        .await
+        .map_err(|err| SourceDestError::build(err, SourceDestErrorKind::SymlinkFile, src, dst))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,9 @@ This crate will generally be conservative with rust version updates. It uses the
 
 If the `tokio` feature is enabled, this crate will inherit the MSRV of the selected [`tokio`](https://crates.io/crates/tokio) version.
 
+If the `smol` feature is enabled, this crate will inherit the MSRV of the selected [`smol`](https://crates.io/crates/smol) version.
+
+
 [std::fs]: https://doc.rust-lang.org/stable/std/fs/
 [std::io::Error]: https://doc.rust-lang.org/stable/std/io/struct.Error.html
 [std::io::Read]: https://doc.rust-lang.org/stable/std/io/trait.Read.html
@@ -83,6 +86,9 @@ If the `tokio` feature is enabled, this crate will inherit the MSRV of the selec
 #![deny(missing_debug_implementations, missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+#[cfg(feature = "async-fs")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async-fs")))]
+pub mod async_fs;
 mod dir;
 mod errors;
 mod file;

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -37,4 +37,13 @@ pub mod fs {
         /// Wrapper for [`OpenOptionsExt::custom_flags`](https://doc.rust-lang.org/std/os/unix/fs/trait.OpenOptionsExt.html#tymethod.custom_flags)
         fn custom_flags(&mut self, flags: i32) -> &mut Self;
     }
+
+    /// Wrapper for [`std::os::unix::fs::DirEntryExt`](https://doc.rust-lang.org/std/os/unix/fs/trait.DirEntryExt.html)
+    ///
+    /// The std traits might be extended in the future (See issue [#49961](https://github.com/rust-lang/rust/issues/49961#issuecomment-382751777)).
+    /// This trait is sealed and can not be implemented by other crates.
+    pub trait DirEntryExt: crate::Sealed {
+        /// Wrapper for [`DirEntryExt::ino`](https://doc.rust-lang.org/std/os/unix/fs/trait.DirEntryExt.html#tymethod.ino)
+        fn ino(&self) -> u64;
+    }
 }


### PR DESCRIPTION
This pull request adds wrappers for [`async-fs`](https://crates.io/crates/async-fs) types (used by [`smol`](https://crates.io/crates/smol)), similar to #40. The wrappers are kept behind the optional `async-fs` feature.