### PR TITLE
Wrap locking methods added to `File` in Rust 1.89 (#74)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,8 +2,9 @@ extern crate autocfg;
 
 fn main() {
     let ac = autocfg::new();
-    // Allows `#[cfg(rustc_1_63)]` to be used in code
+    // Allows `#[cfg(rustc_1_63)]` and `#[cfg(rustc_1_89)]` to be used in code
     ac.emit_rustc_version(1, 63);
+    ac.emit_rustc_version(1, 89);
 
     // Re-run if this file changes
     autocfg::rerun_path("build.rs");

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,6 +25,8 @@ pub(crate) enum ErrorKind {
     SymlinkMetadata,
     #[allow(dead_code)]
     FileExists,
+    Lock,
+    Unlock,
 
     #[cfg(windows)]
     SeekRead,
@@ -89,6 +91,8 @@ impl fmt::Display for Error {
                 write!(formatter, "failed to query metadata of symlink `{}`", path)
             }
             E::FileExists => write!(formatter, "failed to check file existence `{}`", path),
+            E::Lock => write!(formatter, "failed to lock `{}`", path),
+            E::Unlock => write!(formatter, "failed to unlock `{}`", path),
 
             #[cfg(windows)]
             E::SeekRead => write!(formatter, "failed to seek and read from `{}`", path),

--- a/src/file.rs
+++ b/src/file.rs
@@ -146,6 +146,45 @@ impl File {
     }
 }
 
+/// Locking methods added in Rust 1.89.
+#[cfg(rustc_1_89)]
+impl File {
+    /// Acquire an exclusive lock on the file. Blocks until the lock can be acquired.
+    ///
+    /// Wrapper for [`File::lock()`](https://doc.rust-lang.org/nightly/std/fs/struct.File.html#method.lock).
+    pub fn lock(&self) -> Result<(), io::Error> {
+        self.file.lock()
+    }
+
+    /// Acquire a shared (non-exclusive) lock on the file. Blocks until the lock can be acquired.
+    ///
+    /// Wrapper for [`File::lock_shared()`](https://doc.rust-lang.org/nightly/std/fs/struct.File.html#method.lock_shared).
+    pub fn lock_shared(&self) -> Result<(), io::Error> {
+        self.file.lock_shared()
+    }
+
+    /// Try to acquire an exclusive lock on the file.
+    ///
+    /// Wrapper for [`File::try_lock()`](https://doc.rust-lang.org/nightly/std/fs/struct.File.html#method.try_lock).
+    pub fn try_lock(&self) -> Result<(), fs::TryLockError> {
+        self.file.try_lock()
+    }
+
+    /// Try to acquire a shared (non-exclusive) lock on the file.
+    ///
+    /// Wrapper for [`File::try_lock_shared()`](https://doc.rust-lang.org/nightly/std/fs/struct.File.html#method.try_lock_shared).
+    pub fn try_lock_shared(&self) -> Result<(), fs::TryLockError> {
+        self.file.try_lock_shared()
+    }
+
+    /// Release all locks on the file.
+    ///
+    /// Wrapper for [`File::unlock()`](https://doc.rust-lang.org/nightly/std/fs/struct.File.html#method.unlock).
+    pub fn unlock(&self) -> Result<(), io::Error> {
+        self.file.unlock()
+    }
+}
+
 /// Methods added by fs-err that are not available on
 /// [`std::fs::File`][std::fs::File].
 ///

--- a/src/file.rs
+++ b/src/file.rs
@@ -153,14 +153,18 @@ impl File {
     ///
     /// Wrapper for [`File::lock()`](https://doc.rust-lang.org/nightly/std/fs/struct.File.html#method.lock).
     pub fn lock(&self) -> Result<(), io::Error> {
-        self.file.lock()
+        self.file
+            .lock()
+            .map_err(|source| self.error(source, ErrorKind::Lock))
     }
 
     /// Acquire a shared (non-exclusive) lock on the file. Blocks until the lock can be acquired.
     ///
     /// Wrapper for [`File::lock_shared()`](https://doc.rust-lang.org/nightly/std/fs/struct.File.html#method.lock_shared).
     pub fn lock_shared(&self) -> Result<(), io::Error> {
-        self.file.lock_shared()
+        self.file
+            .lock_shared()
+            .map_err(|source| self.error(source, ErrorKind::Lock))
     }
 
     /// Try to acquire an exclusive lock on the file.
@@ -181,7 +185,9 @@ impl File {
     ///
     /// Wrapper for [`File::unlock()`](https://doc.rust-lang.org/nightly/std/fs/struct.File.html#method.unlock).
     pub fn unlock(&self) -> Result<(), io::Error> {
-        self.file.unlock()
+        self.file
+            .unlock()
+            .map_err(|source| self.error(source, ErrorKind::Unlock))
     }
 }
 


### PR DESCRIPTION
Resolves #74.