### PR TITLE
fs-err: Use AsRef<Path> to match std::fs

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -1,19 +1,19 @@
 use std::ffi::OsString;
 use std::fs;
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::errors::{Error, ErrorKind};
 
 /// Returns an iterator over the entries within a directory.
 ///
 /// Wrapper for [`fs::read_dir`](https://doc.rust-lang.org/stable/std/fs/fn.read_dir.html).
-pub fn read_dir<P: Into<PathBuf>>(path: P) -> io::Result<ReadDir> {
-    let path = path.into();
+pub fn read_dir<P: AsRef<Path>>(path: P) -> io::Result<ReadDir> {
+    let path = path.as_ref();
 
-    match fs::read_dir(&path) {
-        Ok(inner) => Ok(ReadDir { inner, path }),
-        Err(source) => Err(Error::build(source, ErrorKind::ReadDir, path)),
+    match fs::read_dir(path) {
+        Ok(inner) => Ok(ReadDir { inner, path: path.to_path_buf() }),
+        Err(source) => Err(Error::build(source, ErrorKind::ReadDir, path.to_path_buf())),
     }
 }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -33,47 +33,38 @@ impl File {
     /// Attempts to open a file in read-only mode.
     ///
     /// Wrapper for [`File::open`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.open).
-    pub fn open<P>(path: P) -> Result<Self, io::Error>
-    where
-        P: Into<PathBuf>,
-    {
-        let path = path.into();
-        match open(&path) {
-            Ok(file) => Ok(File::from_parts(file, path)),
-            Err(err_gen) => Err(err_gen(path)),
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, io::Error> {
+        let path = path.as_ref();
+        match open(path) {
+            Ok(file) => Ok(File::from_parts(file, path.to_path_buf())),
+            Err(err_gen) => Err(err_gen(path.to_path_buf())),
         }
     }
 
     /// Opens a file in write-only mode.
     ///
     /// Wrapper for [`File::create`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.create).
-    pub fn create<P>(path: P) -> Result<Self, io::Error>
-    where
-        P: Into<PathBuf>,
-    {
-        let path = path.into();
-        match create(&path) {
-            Ok(file) => Ok(File::from_parts(file, path)),
-            Err(err_gen) => Err(err_gen(path)),
+    pub fn create<P: AsRef<Path>>(path: P) -> Result<Self, io::Error> {
+        let path = path.as_ref();
+        match create(path) {
+            Ok(file) => Ok(File::from_parts(file, path.to_path_buf())),
+            Err(err_gen) => Err(err_gen(path.to_path_buf())),
         }
     }
 
     /// Opens a file in read-write mode.
     ///
     /// Wrapper for [`File::create_new`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.create_new).
-    pub fn create_new<P>(path: P) -> Result<Self, io::Error>
-    where
-        P: Into<PathBuf>,
-    {
-        let path = path.into();
+    pub fn create_new<P: AsRef<Path>>(path: P) -> Result<Self, io::Error> {
+        let path = path.as_ref();
         // TODO: Use fs::File::create_new once MSRV is at least 1.77
         match fs::OpenOptions::new()
             .read(true)
             .write(true)
             .create_new(true)
-            .open(&path)
+            .open(path)
         {
-            Ok(file) => Ok(File::from_parts(file, path)),
+            Ok(file) => Ok(File::from_parts(file, path.to_path_buf())),
             Err(err) => Err(Error::build(err, ErrorKind::CreateFile, path)),
         }
     }

--- a/src/open_options.rs
+++ b/src/open_options.rs
@@ -1,4 +1,4 @@
-use std::{fs, io, path::PathBuf};
+use std::{fs, io, path::{Path, PathBuf}};
 
 use crate::errors::{Error, ErrorKind};
 
@@ -66,13 +66,10 @@ impl OpenOptions {
     /// Opens a file at `path` with the options specified by `self`.
     ///
     /// Wrapper for [`std::fs::OpenOptions::open`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.open)
-    pub fn open<P>(&self, path: P) -> io::Result<crate::File>
-    where
-        P: Into<PathBuf>,
-    {
-        let path = path.into();
+    pub fn open<P: AsRef<Path>>(&self, path: P) -> io::Result<crate::File> {
+        let path = path.as_ref();
         match self.0.open(&path) {
-            Ok(file) => Ok(crate::File::from_parts(file, path)),
+            Ok(file) => Ok(crate::File::from_parts(file, path.to_path_buf())),
             Err(source) => Err(Error::build(source, ErrorKind::OpenFile, path)),
         }
     }


### PR DESCRIPTION
In order for fs-err to be a drop-in replacement for std::fs, it needs to match the std::fs signature exactly.

Note that this can result in an extra allocation when the path provided is already a PathBuf, but keeping the same API as std::fs is better than over-optimizing for that case.

Fixes #34.