### PR TITLE
Fix CI by installing clippy and rustfmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ matrix.rust_version }}
+          components: ${{ matrix.rust_version == 'stable' && 'clippy,rustfmt' || '' }}
 
       - run: cargo update
         if: ${{ matrix.rust_version == 'stable' || matrix.rust_version == 'beta' }}


### PR DESCRIPTION
Two out of six CI workflows (those with the stable Rust version) fail on the `cargo fmt` step because rustfmt is not installed. Perhaps they'll also fail on the `cargo clippy` step for the similar reason.

E.g. see https://github.com/andrewhickman/fs-err/actions/runs/18052462380/job/51381541868?pr=77:
```
/home/runner/.cargo/bin/cargo fmt --all -- --check
error: 'cargo-fmt' is not installed for the toolchain 'stable-x86_64-unknown-linux-gnu'.
Error: To install, run `rustup component add rustfmt`
Error: The process '/home/runner/.cargo/bin/cargo' failed with exit code 1
```

To fix the CI, this PR enables clippy and rustfmt component on stable workflows.