### PR TITLE
Add `debug` feature (no MSRV change)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,17 @@ jobs:
         with:
           command: check
           args: --features expose_original_error
+
+      - name: cargo check --features debug
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --features debug
+        if: ${{ matrix.rust_version == 'stable' || matrix.rust_version == 'beta' }}
+
+      - name: cargo check --features debug_tokio,tokio
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --features debug_tokio,tokio
+        if: ${{ matrix.rust_version == 'stable' || matrix.rust_version == 'beta' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # fs-err Changelog
 
+* Introduce `debug` and `debug_tokio` feature. Debug filesystem errors faster by exposing more information ([#81](https://github.com/andrewhickman/fs-err/pull/81)). Without this feature on, errors might look like this:
+
+  ```
+  failed to open file `file.txt`: The system cannot find the file specified. (os error 2)
+  ```
+
+  With this feature on, it will include additional information. For example:
+
+  ```
+  failed to open file `file.txt`: The system cannot find the file specified. (os error 2)
+
+  Path does not exist `file.txt`
+  - Absolute path `/path/to/dir/file.txt`
+  - Missing `file.txt` from parent directory:
+    `/path/to/dir`
+      └── `file.md`
+      └── `different.txt`
+  ```
+
+  It's suggested to enable this feature in `dev-dependencies` for security and performance reasons.
+
 ## 3.1.3
 
 * Add wrappers for `std::fs::exists` and `tokio::fs::try_exists` ([#77](https://github.com/andrewhickman/fs-err/pull/77))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "cc"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,10 +57,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "faccess"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ae66425802d6a903e268ae1a08b8c38ba143520f227a205edf4e9c7e3e26d5"
+dependencies = [
+ "bitflags",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fs-err"
 version = "3.1.3"
 dependencies = [
  "autocfg",
+ "path_facts",
  "serde_json",
  "tokio",
 ]
@@ -67,9 +85,9 @@ checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "libc"
@@ -99,6 +117,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "path_facts"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "066b565df0c3e87b875a3a9da8b572de660deba7e7e4a940cd766767746499ba"
+dependencies = [
+ "faccess",
 ]
 
 [[package]]
@@ -159,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.100"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
@@ -194,3 +221,25 @@ name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,21 @@ exclude = [".github", ".gitignore", "README.tpl"]
 
 [dependencies]
 tokio = { version = "1.21", optional = true, default-features = false, features = ["fs"] }
+path_facts = { version = "0.2.0", optional = true }
 
 [build-dependencies]
 autocfg = "1"
 
 [dev-dependencies]
-serde_json = "1.0.64"
+serde_json = "=1.0.64"
 
 [features]
+# Debug filesystem errors faster by exposing more information. Suggested for use in `dev-dependencies`.
+# Note: Requires Rust 1.79+ due to path_facts dependency
+debug = ["path_facts"]
+
+debug_tokio = ["path_facts", "tokio/rt-multi-thread"]
+
 # Allow custom formatting of the error source
 #
 # When enabled errors emit `std::error::Error::source()` as Some (default is `None`) and

--- a/README.md
+++ b/README.md
@@ -69,7 +69,33 @@ println!("Program config: {:?}", decoded);
 
 * `expose_original_error`: when enabled, the [`Error::source()`](https://doc.rust-lang.org/stable/std/error/trait.Error.html#method.source) method of errors returned by this crate return the original `io::Error`. To avoid duplication in error messages,
   this also suppresses printing its message in their `Display` implementation, so make sure that you are printing the full error chain.
+* `debug`: Debug filesystem errors faster by exposing more information. When a filesystem command
+  fails, the error message might say "file does not exist." But it won't say **why** it doesn't exist.
+  Perhaps the programmer misspelled the filename, perhaps that directory doesn't exist, or if it does,
+  but the current user doesn't have permissions to see the contents. This feature analyzes the filesystem
+  to output various "facts" that will help a developer debug the root of the current error.
+  * Warning: Exposes filesystem metadata. This feature exposes additional metadata about your filesystem
+    such as directory contents and permissions, which may be sensitive. Only enable `debug` when
+    error messages won't be displayed to the end user, or they have access to filesystem metadata some
+    other way.
+  * Warning: This may slow down your program. This feature will trigger additional filesystem calls when
+    errors occur, which may cause performance issues. Do not use if filesystem errors are common on a
+    performance-sensitive "hotpath." Use in scenarios where developer hours are more expensive than
+    compute time.
+  * To mitigate performance and security concerns, consider only enabling this feature in `dev-dependencies`:
+  * Requires Rust 1.79 or later
 
+```toml
+[dev-dependencies]
+fs-err = { features = ["debug"] }
+```
+
+To use with the `tokio` feature, use `debug_tokio`:
+
+```toml
+[dependencies]
+fs-err = { features = ["debug_tokio", "tokio"] }
+```
 
 ## Minimum Supported Rust Version
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,33 @@ println!("Program config: {:?}", decoded);
 
 * `expose_original_error`: when enabled, the [`Error::source()`](https://doc.rust-lang.org/stable/std/error/trait.Error.html#method.source) method of errors returned by this crate return the original `io::Error`. To avoid duplication in error messages,
   this also suppresses printing its message in their `Display` implementation, so make sure that you are printing the full error chain.
+* `debug`: Debug filesystem errors faster by exposing more information. When a filesystem command
+  fails, the error message might say "file does not exist." But it won't say **why** it doesn't exist.
+  Perhaps the programmer misspelled the filename, perhaps that directory doesn't exist, or if it does,
+  but the current user doesn't have permissions to see the contents. This feature analyzes the filesystem
+  to output various "facts" that will help a developer debug the root of the current error.
+  * Warning: Exposes filesystem metadata. This feature exposes additional metadata about your filesystem
+    such as directory contents and permissions, which may be sensitive. Only enable `debug` when
+    error messages won't be displayed to the end user, or they have access to filesystem metadata some
+    other way.
+  * Warning: This may slow down your program. This feature will trigger additional filesystem calls when
+    errors occur, which may cause performance issues. Do not use if filesystem errors are common on a
+    performance-sensitive "hotpath." Use in scenarios where developer hours are more expensive than
+    compute time.
+  * To mitigate performance and security concerns, consider only enabling this feature in `dev-dependencies`:
+  * Requires Rust 1.79 or later
 
+```toml
+[dev-dependencies]
+fs-err = { features = ["debug"] }
+```
+
+To use with the `tokio` feature, use `debug_tokio`:
+
+```toml
+[dependencies]
+fs-err = { features = ["debug_tokio", "tokio"] }
+```
 
 # Minimum Supported Rust Version
 


### PR DESCRIPTION
Before:

```
failed to open file `file.txt`: The system cannot find the file specified. (os error 2)
```

After (with `debug` feature):

```
failed to open file `file.txt`: The system cannot find the file specified. (os error 2)

Path does not exist `file.txt`
- Absolute path `/path/to/dir/file.txt`
- Missing `file.txt` from parent directory:
  `/path/to/dir`
    └── `file.md`
    └── `different.txt`
```

Alternative to #80 that does not change MSRV but requires developers using both `tokio` and `debug` to enable `tokio/rt-multi-thread`. This can also be done via the `debug_tokio` feature.

Close #55