### PR TITLE
Cleanup rustdoc links

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -5,9 +5,12 @@ use std::path::PathBuf;
 
 use crate::errors::{Error, ErrorKind};
 
+#[allow(unused_imports)]
+use crate as fs_err; // for docs
+
 /// Returns an iterator over the entries within a directory.
 ///
-/// Wrapper for [`fs::read_dir`](https://doc.rust-lang.org/stable/std/fs/fn.read_dir.html).
+/// Wrapper for [`std::fs::read_dir`].
 pub fn read_dir<P: Into<PathBuf>>(path: P) -> io::Result<ReadDir> {
     let path = path.into();
 
@@ -17,13 +20,10 @@ pub fn read_dir<P: Into<PathBuf>>(path: P) -> io::Result<ReadDir> {
     }
 }
 
-/// Wrapper around [`std::fs::ReadDir`][std::fs::ReadDir] which adds more
-/// helpful information to all errors.
+/// Wrapper around [`std::fs::ReadDir`] which adds more helpful information to
+/// all errors.
 ///
-/// This struct is created via [`fs_err::read_dir`][fs_err::read_dir].
-///
-/// [std::fs::ReadDir]: https://doc.rust-lang.org/stable/std/fs/struct.ReadDir.html
-/// [fs_err::read_dir]: fn.read_dir.html
+/// This struct is created via [`fs_err::read_dir`].
 #[derive(Debug)]
 pub struct ReadDir {
     inner: fs::ReadDir,
@@ -43,10 +43,8 @@ impl Iterator for ReadDir {
     }
 }
 
-/// Wrapper around [`std::fs::DirEntry`][std::fs::DirEntry] which adds more
+/// Wrapper around [`std::fs::DirEntry`] which adds more
 /// helpful information to all errors.
-///
-/// [std::fs::DirEntry]: https://doc.rust-lang.org/stable/std/fs/struct.DirEntry.html
 #[derive(Debug)]
 pub struct DirEntry {
     inner: fs::DirEntry,
@@ -55,14 +53,14 @@ pub struct DirEntry {
 impl DirEntry {
     /// Returns the full path to the file that this entry represents.
     ///
-    /// Wrapper for [`DirEntry::path`](https://doc.rust-lang.org/stable/std/fs/struct.DirEntry.html#method.path).
+    /// Wrapper for [`std::fs::DirEntry::path`].
     pub fn path(&self) -> PathBuf {
         self.inner.path()
     }
 
     /// Returns the metadata for the file that this entry points at.
     ///
-    /// Wrapper for [`DirEntry::metadata`](https://doc.rust-lang.org/stable/std/fs/struct.DirEntry.html#method.metadata).
+    /// Wrapper for [`std::fs::DirEntry::metadata`].
     pub fn metadata(&self) -> io::Result<fs::Metadata> {
         self.inner
             .metadata()
@@ -71,7 +69,7 @@ impl DirEntry {
 
     /// Returns the file type for the file that this entry points at.
     ///
-    /// Wrapper for [`DirEntry::file_type`](https://doc.rust-lang.org/stable/std/fs/struct.DirEntry.html#method.file_type).
+    /// Wrapper for [`std::fs::DirEntry::file_type`].
     pub fn file_type(&self) -> io::Result<fs::FileType> {
         self.inner
             .file_type()
@@ -80,7 +78,7 @@ impl DirEntry {
 
     /// Returns the file name of this directory entry without any leading path component(s).
     ///
-    /// Wrapper for [`DirEntry::file_name`](https://doc.rust-lang.org/stable/std/fs/struct.DirEntry.html#method.file_name).
+    /// Wrapper for [`std::fs::DirEntry::file_name`].
     pub fn file_name(&self) -> OsString {
         self.inner.file_name()
     }

--- a/src/file.rs
+++ b/src/file.rs
@@ -9,34 +9,35 @@ use std::{fs::FileTimes, time::SystemTime};
 use crate::errors::{Error, ErrorKind};
 use crate::OpenOptions;
 
-/// Wrapper around [`std::fs::File`][std::fs::File] which adds more helpful
-/// information to all errors.
-///
-/// [std::fs::File]: https://doc.rust-lang.org/stable/std/fs/struct.File.html
+#[allow(unused_imports)]
+use crate as fs_err; // for docs
+
+/// Wrapper around [`std::fs::File`] which adds more helpful information to all
+/// errors.
 #[derive(Debug)]
 pub struct File {
     file: fs::File,
     path: PathBuf,
 }
 
-// Opens a std File and returns it or an error generator which only needs the path to produce the error.
-// Exists for the `crate::read*` functions so they don't unconditionally build a PathBuf.
+/// Opens a [`std::fs::File`] and returns it or an error generator which only
+/// needs the path to produce the error.
+/// Exists for the `crate::read*` functions so they don't unconditionally build
+/// a [`PathBuf`].
 pub(crate) fn open(path: &Path) -> Result<std::fs::File, impl FnOnce(PathBuf) -> io::Error> {
     fs::File::open(path).map_err(|err| |path| Error::build(err, ErrorKind::OpenFile, path))
 }
 
-// like `open()` but for `crate::write`
+/// like [`open()`] but for [`crate::write`].
 pub(crate) fn create(path: &Path) -> Result<std::fs::File, impl FnOnce(PathBuf) -> io::Error> {
     fs::File::create(path).map_err(|err| |path| Error::build(err, ErrorKind::CreateFile, path))
 }
 
-/// Wrappers for methods from [`std::fs::File`][std::fs::File].
-///
-/// [std::fs::File]: https://doc.rust-lang.org/stable/std/fs/struct.File.html
+/// Wrappers for methods from [`std::fs::File`].
 impl File {
     /// Attempts to open a file in read-only mode.
     ///
-    /// Wrapper for [`File::open`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.open).
+    /// Wrapper for [`std::fs::File::open`].
     pub fn open<P>(path: P) -> Result<Self, io::Error>
     where
         P: Into<PathBuf>,
@@ -50,7 +51,7 @@ impl File {
 
     /// Opens a file in write-only mode.
     ///
-    /// Wrapper for [`File::create`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.create).
+    /// Wrapper for [`std::fs::File::create`].
     pub fn create<P>(path: P) -> Result<Self, io::Error>
     where
         P: Into<PathBuf>,
@@ -64,7 +65,7 @@ impl File {
 
     /// Opens a file in read-write mode.
     ///
-    /// Wrapper for [`File::create_new`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.create_new).
+    /// Wrapper for [`std::fs::File::create_new`].
     pub fn create_new<P>(path: P) -> Result<Self, io::Error>
     where
         P: Into<PathBuf>,
@@ -84,23 +85,26 @@ impl File {
 
     /// Returns a new `OpenOptions` object.
     ///
-    /// Wrapper for [`File::options`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.options).
+    /// Wrapper for [`std::fs::File::options`].
     pub fn options() -> OpenOptions {
         OpenOptions::new()
     }
 
     /// Attempts to sync all OS-internal metadata to disk.
     ///
-    /// Wrapper for [`File::sync_all`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.sync_all).
+    /// Wrapper for [`std::fs::File::sync_all`].
     pub fn sync_all(&self) -> Result<(), io::Error> {
         self.file
             .sync_all()
             .map_err(|source| self.error(source, ErrorKind::SyncFile))
     }
 
-    /// This function is similar to [`sync_all`], except that it might not synchronize file metadata to the filesystem.
+    /// This function is similar to [`sync_all`], except that it might not
+    /// synchronize file metadata to the filesystem.
     ///
-    /// Wrapper for [`File::sync_data`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.sync_data).
+    /// Wrapper for [`std::fs::File::sync_data`].
+    ///
+    /// [`sync_all`]: File::sync_all
     pub fn sync_data(&self) -> Result<(), io::Error> {
         self.file
             .sync_data()
@@ -109,7 +113,7 @@ impl File {
 
     /// Truncates or extends the underlying file, updating the size of this file to become `size`.
     ///
-    /// Wrapper for [`File::set_len`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.set_len).
+    /// Wrapper for [`std::fs::File::set_len`].
     pub fn set_len(&self, size: u64) -> Result<(), io::Error> {
         self.file
             .set_len(size)
@@ -118,7 +122,7 @@ impl File {
 
     /// Queries metadata about the underlying file.
     ///
-    /// Wrapper for [`File::metadata`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.metadata).
+    /// Wrapper for [`std::fs::File::metadata`].
     pub fn metadata(&self) -> Result<fs::Metadata, io::Error> {
         self.file
             .metadata()
@@ -129,7 +133,7 @@ impl File {
     /// existing `File` instance. Reads, writes, and seeks will affect both `File`
     /// instances simultaneously.
     ///
-    /// Wrapper for [`File::try_clone`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.try_clone).
+    /// Wrapper for [`std::fs::File::try_clone`].
     pub fn try_clone(&self) -> Result<Self, io::Error> {
         self.file
             .try_clone()
@@ -142,7 +146,7 @@ impl File {
 
     /// Changes the permissions on the underlying file.
     ///
-    /// Wrapper for [`File::set_permissions`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.set_permissions).
+    /// Wrapper for [`std::fs::File::set_permissions`].
     pub fn set_permissions(&self, perm: fs::Permissions) -> Result<(), io::Error> {
         self.file
             .set_permissions(perm)
@@ -155,7 +159,7 @@ impl File {
 impl File {
     /// Changes the timestamps of the underlying file.
     ///
-    /// Wrapper for [`File::set_times`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.set_times).
+    /// Wrapper for [`std::fs::File::set_times`].
     pub fn set_times(&self, times: FileTimes) -> Result<(), io::Error> {
         self.file
             .set_times(times)
@@ -164,7 +168,7 @@ impl File {
 
     /// Changes the modification time of the underlying file.
     ///
-    /// Wrapper for [`File::set_modified`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.set_modified).
+    /// Wrapper for [`std::fs::File::set_modified`].
     pub fn set_modified(&self, time: SystemTime) -> Result<(), io::Error> {
         self.file
             .set_modified(time)
@@ -177,7 +181,7 @@ impl File {
 impl File {
     /// Acquire an exclusive lock on the file. Blocks until the lock can be acquired.
     ///
-    /// Wrapper for [`File::lock()`](https://doc.rust-lang.org/nightly/std/fs/struct.File.html#method.lock).
+    /// Wrapper for [`std::fs::File::lock`].
     pub fn lock(&self) -> Result<(), io::Error> {
         self.file
             .lock()
@@ -186,7 +190,7 @@ impl File {
 
     /// Acquire a shared (non-exclusive) lock on the file. Blocks until the lock can be acquired.
     ///
-    /// Wrapper for [`File::lock_shared()`](https://doc.rust-lang.org/nightly/std/fs/struct.File.html#method.lock_shared).
+    /// Wrapper for [`std::fs::File::lock_shared`].
     pub fn lock_shared(&self) -> Result<(), io::Error> {
         self.file
             .lock_shared()
@@ -195,21 +199,21 @@ impl File {
 
     /// Try to acquire an exclusive lock on the file.
     ///
-    /// Wrapper for [`File::try_lock()`](https://doc.rust-lang.org/nightly/std/fs/struct.File.html#method.try_lock).
+    /// Wrapper for [`std::fs::File::try_lock`].
     pub fn try_lock(&self) -> Result<(), fs::TryLockError> {
         self.file.try_lock()
     }
 
     /// Try to acquire a shared (non-exclusive) lock on the file.
     ///
-    /// Wrapper for [`File::try_lock_shared()`](https://doc.rust-lang.org/nightly/std/fs/struct.File.html#method.try_lock_shared).
+    /// Wrapper for [`std::fs::File::try_lock_shared`].
     pub fn try_lock_shared(&self) -> Result<(), fs::TryLockError> {
         self.file.try_lock_shared()
     }
 
     /// Release all locks on the file.
     ///
-    /// Wrapper for [`File::unlock()`](https://doc.rust-lang.org/nightly/std/fs/struct.File.html#method.unlock).
+    /// Wrapper for [`std::fs::File::unlock`].
     pub fn unlock(&self) -> Result<(), io::Error> {
         self.file
             .unlock()
@@ -217,12 +221,9 @@ impl File {
     }
 }
 
-/// Methods added by fs-err that are not available on
-/// [`std::fs::File`][std::fs::File].
-///
-/// [std::fs::File]: https://doc.rust-lang.org/stable/std/fs/struct.File.html
+/// Methods added by fs-err that are not available on [`std::fs::File`].
 impl File {
-    /// Creates a [`File`](struct.File.html) from a raw file and its path.
+    /// Creates a [`fs_err::File`] from a file and its path.
     pub fn from_parts<P>(file: fs::File, path: P) -> Self
     where
         P: Into<PathBuf>,
@@ -233,33 +234,27 @@ impl File {
         }
     }
 
-    /// Extract the raw file and its path from this [`File`](struct.File.html)
+    /// Extract the raw file and its path from this [`fs_err::File`].
     pub fn into_parts(self) -> (fs::File, PathBuf) {
         (self.file, self.path)
     }
 
-    /// Consumes this [`File`](struct.File.html) and returns the underlying
-    /// [`std::fs::File`][std::fs::File].
+    /// Consumes this `File` and returns the underlying [`std::fs::File`].
     pub fn into_file(self) -> fs::File {
         self.file
     }
 
-    /// Consumes this [`File`](struct.File.html) and returns the underlying
-    /// path as a [`PathBuf`].
+    /// Consumes this `File` and returns the underlying path as a [`PathBuf`].
     pub fn into_path(self) -> PathBuf {
         self.path
     }
 
-    /// Returns a reference to the underlying [`std::fs::File`][std::fs::File].
-    ///
-    /// [std::fs::File]: https://doc.rust-lang.org/stable/std/fs/struct.File.html
+    /// Returns a reference to the underlying [`std::fs::File`].
     pub fn file(&self) -> &fs::File {
         &self.file
     }
 
-    /// Returns a mutable reference to the underlying [`std::fs::File`][std::fs::File].
-    ///
-    /// [std::fs::File]: https://doc.rust-lang.org/stable/std/fs/struct.File.html
+    /// Returns a mutable reference to the underlying [`std::fs::File`].
     pub fn file_mut(&mut self) -> &mut fs::File {
         &mut self.file
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
 /*!
-fs-err is a drop-in replacement for [`std::fs`][std::fs] that provides more
+fs-err is a drop-in replacement for [`std::fs`] that provides more
 helpful messages on errors. Extra information includes which operations was
 attempted and any involved paths.
 
 # Error Messages
 
-Using [`std::fs`][std::fs], if this code fails:
+Using [`std::fs`], if this code fails:
 
 ```no_run
 # use std::fs::File;
@@ -27,7 +27,7 @@ failed to open file `does not exist.txt`: The system cannot find the file specif
 
 # Usage
 
-fs-err's API is the same as [`std::fs`][std::fs], so migrating code to use it is easy.
+fs-err's API is the same as [`std::fs`], so migrating code to use it is easy.
 
 ```no_run
 // use std::fs;
@@ -40,10 +40,9 @@ println!("Read foo.txt: {}", contents);
 # Ok::<(), std::io::Error>(())
 ```
 
-fs-err uses [`std::io::Error`][std::io::Error] for all errors. This helps fs-err
-compose well with traits from the standard library like
-[`std::io::Read`][std::io::Read] and crates that use them like
-[`serde_json`][serde_json]:
+fs-err uses [`std::io::Error`] for all errors. This helps fs-err compose well
+with traits from the standard library like [`std::io::Read`] and crates that
+use them like [`serde_json`]:
 
 ```no_run
 use fs_err::File;
@@ -61,8 +60,10 @@ println!("Program config: {:?}", decoded);
 
 # Feature flags
 
-* `expose_original_error`: when enabled, the [`Error::source()`](https://doc.rust-lang.org/stable/std/error/trait.Error.html#method.source) method of errors returned by this crate return the original `io::Error`. To avoid duplication in error messages,
-  this also suppresses printing its message in their `Display` implementation, so make sure that you are printing the full error chain.
+* `expose_original_error`: when enabled, the [`std::error::Error::source`] method of errors returned
+  by this crate return the original [`std::io::Error`]. To avoid duplication in error messages,
+  this also suppresses printing its message in their `Display` implementation, so make sure that you
+  are printing the full error chain.
 * `debug`: Debug filesystem errors faster by exposing more information. When a filesystem command
   fails, the error message might say "file does not exist." But it won't say **why** it doesn't exist.
   Perhaps the programmer misspelled the filename, perhaps that directory doesn't exist, or if it does,
@@ -95,14 +96,13 @@ fs-err = { features = ["debug_tokio", "tokio"] }
 
 The oldest rust version this crate is tested on is **1.40**.
 
-This crate will generally be conservative with rust version updates. It uses the [`autocfg`](https://crates.io/crates/autocfg) crate to allow wrapping new APIs without incrementing the MSRV.
+This crate will generally be conservative with rust version updates. It uses the [`autocfg`] crate to allow wrapping new APIs without incrementing the MSRV.
 
-If the `tokio` feature is enabled, this crate will inherit the MSRV of the selected [`tokio`](https://crates.io/crates/tokio) version.
+If the `tokio` feature is enabled, this crate will inherit the MSRV of the selected [`tokio`] version.
 
-[std::fs]: https://doc.rust-lang.org/stable/std/fs/
-[std::io::Error]: https://doc.rust-lang.org/stable/std/io/struct.Error.html
-[std::io::Read]: https://doc.rust-lang.org/stable/std/io/trait.Read.html
-[serde_json]: https://crates.io/crates/serde_json
+[`autocfg`]: https://crates.io/crates/autocfg
+[`serde_json`]: https://crates.io/crates/serde_json
+[`tokio`]: https://crates.io/crates/tokio
 */
 
 #![doc(html_root_url = "https://docs.rs/fs-err/3.2.2")]
@@ -132,7 +132,7 @@ pub use path::PathExt;
 
 /// Read the entire contents of a file into a bytes vector.
 ///
-/// Wrapper for [`fs::read`](https://doc.rust-lang.org/stable/std/fs/fn.read.html).
+/// Wrapper for [`std::fs::read`].
 pub fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
     let path = path.as_ref();
     let mut file = file::open(path).map_err(|err_gen| err_gen(path.to_path_buf()))?;
@@ -144,7 +144,7 @@ pub fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
 
 /// Read the entire contents of a file into a string.
 ///
-/// Wrapper for [`fs::read_to_string`](https://doc.rust-lang.org/stable/std/fs/fn.read_to_string.html).
+/// Wrapper for [`std::fs::read_to_string`].
 pub fn read_to_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
     let path = path.as_ref();
     let mut file = file::open(path).map_err(|err_gen| err_gen(path.to_path_buf()))?;
@@ -156,7 +156,7 @@ pub fn read_to_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
 
 /// Write a slice as the entire contents of a file.
 ///
-/// Wrapper for [`fs::write`](https://doc.rust-lang.org/stable/std/fs/fn.write.html).
+/// Wrapper for [`std::fs::write`].
 pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result<()> {
     let path = path.as_ref();
     file::create(path)
@@ -168,7 +168,7 @@ pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result
 /// Copies the contents of one file to another. This function will also copy the
 /// permission bits of the original file to the destination file.
 ///
-/// Wrapper for [`fs::copy`](https://doc.rust-lang.org/stable/std/fs/fn.copy.html).
+/// Wrapper for [`std::fs::copy`].
 pub fn copy<P, Q>(from: P, to: Q) -> io::Result<u64>
 where
     P: AsRef<Path>,
@@ -182,7 +182,7 @@ where
 
 /// Creates a new, empty directory at the provided path.
 ///
-/// Wrapper for [`fs::create_dir`](https://doc.rust-lang.org/stable/std/fs/fn.create_dir.html).
+/// Wrapper for [`std::fs::create_dir`].
 pub fn create_dir<P>(path: P) -> io::Result<()>
 where
     P: AsRef<Path>,
@@ -193,7 +193,7 @@ where
 
 /// Recursively create a directory and all of its parent components if they are missing.
 ///
-/// Wrapper for [`fs::create_dir_all`](https://doc.rust-lang.org/stable/std/fs/fn.create_dir_all.html).
+/// Wrapper for [`std::fs::create_dir_all`].
 pub fn create_dir_all<P>(path: P) -> io::Result<()>
 where
     P: AsRef<Path>,
@@ -204,7 +204,7 @@ where
 
 /// Removes an empty directory.
 ///
-/// Wrapper for [`fs::remove_dir`](https://doc.rust-lang.org/stable/std/fs/fn.remove_dir.html).
+/// Wrapper for [`std::fs::remove_dir`].
 pub fn remove_dir<P>(path: P) -> io::Result<()>
 where
     P: AsRef<Path>,
@@ -215,7 +215,7 @@ where
 
 /// Removes a directory at this path, after removing all its contents. Use carefully!
 ///
-/// Wrapper for [`fs::remove_dir_all`](https://doc.rust-lang.org/stable/std/fs/fn.remove_dir_all.html).
+/// Wrapper for [`std::fs::remove_dir_all`].
 pub fn remove_dir_all<P>(path: P) -> io::Result<()>
 where
     P: AsRef<Path>,
@@ -226,7 +226,7 @@ where
 
 /// Removes a file from the filesystem.
 ///
-/// Wrapper for [`fs::remove_file`](https://doc.rust-lang.org/stable/std/fs/fn.remove_file.html).
+/// Wrapper for [`std::fs::remove_file`].
 pub fn remove_file<P>(path: P) -> io::Result<()>
 where
     P: AsRef<Path>,
@@ -237,7 +237,7 @@ where
 
 /// Given a path, query the file system to get information about a file, directory, etc.
 ///
-/// Wrapper for [`fs::metadata`](https://doc.rust-lang.org/stable/std/fs/fn.metadata.html).
+/// Wrapper for [`std::fs::metadata`].
 pub fn metadata<P: AsRef<Path>>(path: P) -> io::Result<fs::Metadata> {
     let path = path.as_ref();
     fs::metadata(path).map_err(|source| Error::build(source, ErrorKind::Metadata, path))
@@ -245,7 +245,7 @@ pub fn metadata<P: AsRef<Path>>(path: P) -> io::Result<fs::Metadata> {
 
 /// Returns `Ok(true)` if the path points at an existing entity.
 ///
-/// Wrapper for [`fs::exists`](https://doc.rust-lang.org/stable/std/fs/fn.exists.html).
+/// Wrapper for [`std::fs::exists`].
 #[cfg(rustc_1_81)]
 pub fn exists<P: AsRef<Path>>(path: P) -> io::Result<bool> {
     let path = path.as_ref();
@@ -255,7 +255,7 @@ pub fn exists<P: AsRef<Path>>(path: P) -> io::Result<bool> {
 /// Returns the canonical, absolute form of a path with all intermediate components
 /// normalized and symbolic links resolved.
 ///
-/// Wrapper for [`fs::canonicalize`](https://doc.rust-lang.org/stable/std/fs/fn.canonicalize.html).
+/// Wrapper for [`std::fs::canonicalize`].
 pub fn canonicalize<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
     let path = path.as_ref();
     fs::canonicalize(path).map_err(|source| Error::build(source, ErrorKind::Canonicalize, path))
@@ -267,7 +267,7 @@ pub fn canonicalize<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
 /// systems often require these two paths to both be located on the same
 /// filesystem.
 ///
-/// Wrapper for [`fs::hard_link`](https://doc.rust-lang.org/stable/std/fs/fn.hard_link.html).
+/// Wrapper for [`std::fs::hard_link`].
 pub fn hard_link<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Result<()> {
     let original = original.as_ref();
     let link = link.as_ref();
@@ -278,7 +278,7 @@ pub fn hard_link<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Re
 
 /// Reads a symbolic link, returning the file that the link points to.
 ///
-/// Wrapper for [`fs::read_link`](https://doc.rust-lang.org/stable/std/fs/fn.read_link.html).
+/// Wrapper for [`std::fs::read_link`].
 pub fn read_link<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
     let path = path.as_ref();
     fs::read_link(path).map_err(|source| Error::build(source, ErrorKind::ReadLink, path))
@@ -286,7 +286,7 @@ pub fn read_link<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
 
 /// Rename a file or directory to a new name, replacing the original file if to already exists.
 ///
-/// Wrapper for [`fs::rename`](https://doc.rust-lang.org/stable/std/fs/fn.rename.html).
+/// Wrapper for [`std::fs::rename`].
 pub fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<()> {
     let from = from.as_ref();
     let to = to.as_ref();
@@ -298,7 +298,7 @@ pub fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<()> 
 ///
 /// The `link` path will be a symbolic link pointing to the `original` path.
 ///
-/// Wrapper for [`fs::soft_link`](https://doc.rust-lang.org/stable/std/fs/fn.soft_link.html).
+/// Wrapper for [`std::fs::soft_link`].
 #[deprecated = "replaced with std::os::unix::fs::symlink and \
 std::os::windows::fs::{symlink_file, symlink_dir}"]
 pub fn soft_link<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Result<()> {
@@ -312,7 +312,7 @@ pub fn soft_link<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Re
 
 /// Query the metadata about a file without following symlinks.
 ///
-/// Wrapper for [`fs::symlink_metadata`](https://doc.rust-lang.org/stable/std/fs/fn.symlink_metadata.html).
+/// Wrapper for [`std::fs::symlink_metadata`].
 pub fn symlink_metadata<P: AsRef<Path>>(path: P) -> io::Result<fs::Metadata> {
     let path = path.as_ref();
     fs::symlink_metadata(path)
@@ -321,7 +321,7 @@ pub fn symlink_metadata<P: AsRef<Path>>(path: P) -> io::Result<fs::Metadata> {
 
 /// Changes the permissions found on a file or a directory.
 ///
-/// Wrapper for [`fs::set_permissions`](https://doc.rust-lang.org/stable/std/fs/fn.set_permissions.html).
+/// Wrapper for [`std::fs::set_permissions`].
 pub fn set_permissions<P: AsRef<Path>>(path: P, perm: fs::Permissions) -> io::Result<()> {
     let path = path.as_ref();
     fs::set_permissions(path, perm)

--- a/src/open_options.rs
+++ b/src/open_options.rs
@@ -3,13 +3,13 @@ use std::{fs, io, path::PathBuf};
 use crate::errors::{Error, ErrorKind};
 
 #[derive(Clone, Debug)]
-/// Wrapper around [`std::fs::OpenOptions`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html)
+/// Wrapper for [`std::fs::OpenOptions`].
 pub struct OpenOptions(fs::OpenOptions);
 
 impl OpenOptions {
     /// Creates a blank new set of options ready for configuration.
     ///
-    /// Wrapper for [`std::fs::OpenOptions::new`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.new)
+    /// Wrapper for [`std::fs::OpenOptions::new`].
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         OpenOptions(fs::OpenOptions::new())
@@ -17,7 +17,7 @@ impl OpenOptions {
 
     /// Sets the option for read access.
     ///
-    /// Wrapper for [`std::fs::OpenOptions::read`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.read)
+    /// Wrapper for [`std::fs::OpenOptions::read`].
     pub fn read(&mut self, read: bool) -> &mut Self {
         self.0.read(read);
         self
@@ -25,7 +25,7 @@ impl OpenOptions {
 
     /// Sets the option for write access.
     ///
-    /// Wrapper for [`std::fs::OpenOptions::write`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.write)
+    /// Wrapper for [`std::fs::OpenOptions::write`].
     pub fn write(&mut self, write: bool) -> &mut Self {
         self.0.write(write);
         self
@@ -33,7 +33,7 @@ impl OpenOptions {
 
     /// Sets the option for the append mode.
     ///
-    /// Wrapper for [`std::fs::OpenOptions::append`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.append)
+    /// Wrapper for [`std::fs::OpenOptions::append`].
     pub fn append(&mut self, append: bool) -> &mut Self {
         self.0.append(append);
         self
@@ -41,7 +41,7 @@ impl OpenOptions {
 
     /// Sets the option for truncating a previous file.
     ///
-    /// Wrapper for [`std::fs::OpenOptions::truncate`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.truncate)
+    /// Wrapper for [`std::fs::OpenOptions::truncate`].
     pub fn truncate(&mut self, truncate: bool) -> &mut Self {
         self.0.truncate(truncate);
         self
@@ -49,7 +49,7 @@ impl OpenOptions {
 
     /// Sets the option to create a new file, or open it if it already exists.
     ///
-    /// Wrapper for [`std::fs::OpenOptions::create`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.create)
+    /// Wrapper for [`std::fs::OpenOptions::create`].
     pub fn create(&mut self, create: bool) -> &mut Self {
         self.0.create(create);
         self
@@ -57,7 +57,7 @@ impl OpenOptions {
 
     /// Sets the option to create a new file, failing if it already exists.
     ///
-    /// Wrapper for [`std::fs::OpenOptions::create_new`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.create_new)
+    /// Wrapper for [`std::fs::OpenOptions::create_new`].
     pub fn create_new(&mut self, create_new: bool) -> &mut Self {
         self.0.create_new(create_new);
         self
@@ -65,7 +65,7 @@ impl OpenOptions {
 
     /// Opens a file at `path` with the options specified by `self`.
     ///
-    /// Wrapper for [`std::fs::OpenOptions::open`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.open)
+    /// Wrapper for [`std::fs::OpenOptions::open`].
     pub fn open<P>(&self, path: P) -> io::Result<crate::File>
     where
         P: Into<PathBuf>,
@@ -78,22 +78,21 @@ impl OpenOptions {
     }
 }
 
-/// Methods added by fs-err that are not available on
-/// [`std::fs::OpenOptions`](https://doc.rust-lang.org/stable/std/fs/struct.OpenOptions.html).
+/// Methods added by fs-err that are not available on [`std::fs::OpenOptions`].
 impl OpenOptions {
-    /// Constructs `Self` from [`std::fs::OpenOptions`](https://doc.rust-lang.org/stable/std/fs/struct.OpenOptions.html)
+    /// Constructs `Self` from [`std::fs::OpenOptions`].
     pub fn from_options(options: fs::OpenOptions) -> Self {
         Self(options)
     }
 
-    /// Returns a reference to the underlying [`std::fs::OpenOptions`](https://doc.rust-lang.org/stable/std/fs/struct.OpenOptions.html).
+    /// Returns a reference to the underlying [`std::fs::OpenOptions`].
     ///
     /// Note that calling `open()` on this reference will NOT give you the improved errors from fs-err.
     pub fn options(&self) -> &fs::OpenOptions {
         &self.0
     }
 
-    /// Returns a mutable reference to the underlying [`std::fs::OpenOptions`](https://doc.rust-lang.org/stable/std/fs/struct.OpenOptions.html).
+    /// Returns a mutable reference to the underlying [`std::fs::OpenOptions`].
     ///
     /// This allows you to change settings that don't yet have wrappers in fs-err.
     /// Note that calling `open()` on this reference will NOT give you the improved errors from fs-err.

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -1,4 +1,4 @@
-/// Unix-specific extensions to wrappers in `fs_err` for `std::fs` types.
+/// Unix-specific extensions to wrappers in fs-err for [`std::fs`] types.
 pub mod fs {
     use std::io;
     use std::path::Path;
@@ -11,7 +11,7 @@ pub mod fs {
     ///
     /// The `link` path will be a symbolic link pointing to the `original` path.
     ///
-    /// Wrapper for [`std::os::unix::fs::symlink`](https://doc.rust-lang.org/std/os/unix/fs/fn.symlink.html)
+    /// Wrapper for [`std::os::unix::fs::symlink`].
     pub fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Result<()> {
         let original = original.as_ref();
         let link = link.as_ref();
@@ -24,7 +24,7 @@ pub mod fs {
     ///
     /// Specifying either the uid or gid as `None` will leave it unchanged.
     ///
-    /// Wrapper for [`std::os::unix::fs::chown`](https://doc.rust-lang.org/std/os/unix/fs/fn.chown.html)
+    /// Wrapper for [`std::os::unix::fs::chown`]
     #[cfg(rustc_1_73)]
     pub fn chown<P: AsRef<Path>>(path: P, uid: Option<u32>, gid: Option<u32>) -> io::Result<()> {
         let path = path.as_ref();
@@ -37,7 +37,7 @@ pub mod fs {
     /// Identical to [`chown`], except that if called on a symbolic link, this will change the owner
     /// and group of the link itself rather than the owner and group of the link target.
     ///
-    /// Wrapper for [`std::os::unix::fs::lchown`](https://doc.rust-lang.org/std/os/unix/fs/fn.lchown.html)
+    /// Wrapper for [`std::os::unix::fs::lchown`]
     #[cfg(rustc_1_73)]
     pub fn lchown<P: AsRef<Path>>(path: P, uid: Option<u32>, gid: Option<u32>) -> io::Result<()> {
         let path = path.as_ref();
@@ -49,36 +49,36 @@ pub mod fs {
     ///
     /// This typically requires privileges, such as root or a specific capability.
     ///
-    /// Wrapper for [`std::os::unix::fs::chroot`](https://doc.rust-lang.org/std/os/unix/fs/fn.chroot.html)
+    /// Wrapper for [`std::os::unix::fs::chroot`]
     #[cfg(rustc_1_56)]
     pub fn chroot<P: AsRef<Path>>(path: P) -> io::Result<()> {
         let path = path.as_ref();
         std::os::unix::fs::chroot(path).map_err(|err| Error::build(err, ErrorKind::Chroot, path))
     }
 
-    /// Wrapper for [`std::os::unix::fs::FileExt`](https://doc.rust-lang.org/std/os/unix/fs/trait.FileExt.html).
+    /// Wrapper for [`std::os::unix::fs::FileExt`].
     ///
     /// The std traits might be extended in the future (See issue [#49961](https://github.com/rust-lang/rust/issues/49961#issuecomment-382751777)).
     /// This trait is sealed and can not be implemented by other crates.
     pub trait FileExt: crate::Sealed {
-        /// Wrapper for [`FileExt::read_at`](https://doc.rust-lang.org/std/os/unix/fs/trait.FileExt.html#tymethod.read_at)
+        /// Wrapper for [`std::os::unix::fs::FileExt::read_at`].
         fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize>;
-        /// Wrapper for [`FileExt::read_exact_at`](https://doc.rust-lang.org/std/os/unix/fs/trait.FileExt.html#tymethod.read_exact_at)
+        /// Wrapper for [`std::os::unix::fs::FileExt::read_exact_at`].
         fn read_exact_at(&self, buf: &mut [u8], offset: u64) -> io::Result<()>;
-        /// Wrapper for [`FileExt::write_at`](https://doc.rust-lang.org/std/os/unix/fs/trait.FileExt.html#tymethod.write_at)
+        /// Wrapper for [`std::os::unix::fs::FileExt::write_at`].
         fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize>;
         /// Wrapper for [`FileExt::write_exact_at`](https://doc.rust-lang.org/std/os/unix/fs/trait.FileExt.html#tymethod.write_exact_at)
         fn write_all_at(&self, buf: &[u8], offset: u64) -> io::Result<()>;
     }
 
-    /// Wrapper for [`std::os::unix::fs::OpenOptionsExt`](https://doc.rust-lang.org/std/os/unix/fs/trait.OpenOptionsExt.html)
+    /// Wrapper for [`std::os::unix::fs::OpenOptionsExt`].
     ///
     /// The std traits might be extended in the future (See issue [#49961](https://github.com/rust-lang/rust/issues/49961#issuecomment-382751777)).
     /// This trait is sealed and can not be implemented by other crates.
     pub trait OpenOptionsExt: crate::Sealed {
-        /// Wrapper for [`OpenOptionsExt::mode`](https://doc.rust-lang.org/std/os/unix/fs/trait.OpenOptionsExt.html#tymethod.mode)
+        /// Wrapper for [`std::os::unix::fs::OpenOptionsExt::mode`].
         fn mode(&mut self, mode: u32) -> &mut Self;
-        /// Wrapper for [`OpenOptionsExt::custom_flags`](https://doc.rust-lang.org/std/os/unix/fs/trait.OpenOptionsExt.html#tymethod.custom_flags)
+        /// Wrapper for [`std::os::unix::fs::OpenOptionsExt::custom_flags`].
         fn custom_flags(&mut self, flags: i32) -> &mut Self;
     }
 }

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -1,4 +1,4 @@
-/// Windows-specific extensions to wrappers in `fs_err` for `std::fs` types.
+/// Windows-specific extensions to wrappers in fs-err for [`std::fs`] types.
 pub mod fs {
     use crate::{SourceDestError, SourceDestErrorKind};
     use std::io;
@@ -8,7 +8,7 @@ pub mod fs {
     ///
     /// The `link` path will be a symbolic link pointing to the `original` path.
     ///
-    /// Wrapper for [std::os::windows::fs::symlink_dir](https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_dir.html)
+    /// Wrapper for [`std::os::windows::fs::symlink_dir`].
     pub fn symlink_dir<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Result<()> {
         let original = original.as_ref();
         let link = link.as_ref();
@@ -21,7 +21,7 @@ pub mod fs {
     ///
     /// The `link` path will be a symbolic link pointing to the `original` path.
     ///
-    /// Wrapper for [std::os::windows::fs::symlink_file](https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_file.html)
+    /// Wrapper for [`std::os::windows::fs::symlink_file`].
     pub fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Result<()> {
         let original = original.as_ref();
         let link = link.as_ref();
@@ -30,31 +30,31 @@ pub mod fs {
         })
     }
 
-    /// Wrapper for [`std::os::windows::fs::FileExt`](https://doc.rust-lang.org/std/os/windows/fs/trait.FileExt.html).
+    /// Wrapper for [`std::os::windows::fs::FileExt`].
     ///
     /// The std traits might be extended in the future (See issue [#49961](https://github.com/rust-lang/rust/issues/49961#issuecomment-382751777)).
     /// This trait is sealed and can not be implemented by other crates.
     pub trait FileExt: crate::Sealed {
-        /// Wrapper for [`FileExt::seek_read`](https://doc.rust-lang.org/std/os/windows/fs/trait.FileExt.html#tymethod.seek_read)
+        /// Wrapper for [`std::os::windows::fs::FileExt::seek_read`].
         fn seek_read(&self, buf: &mut [u8], offset: u64) -> io::Result<usize>;
-        /// Wrapper for [`FileExt::seek_wriite`](https://doc.rust-lang.org/std/os/windows/fs/trait.FileExt.html#tymethod.seek_write)
+        /// Wrapper for [`std::os::windows::fs::FileExt::seek_write`].
         fn seek_write(&self, buf: &[u8], offset: u64) -> io::Result<usize>;
     }
 
-    /// Wrapper for [`std::os::windows::fs::OpenOptionsExt`](https://doc.rust-lang.org/std/os/windows/fs/trait.OpenOptionsExt.html)
+    /// Wrapper for [`std::os::windows::fs::OpenOptionsExt`].
     ///
     /// The std traits might be extended in the future (See issue [#49961](https://github.com/rust-lang/rust/issues/49961#issuecomment-382751777)).
     /// This trait is sealed and can not be implemented by other crates.
     pub trait OpenOptionsExt: crate::Sealed {
-        /// Wrapper for [`OpenOptionsExt::access_mode`](https://doc.rust-lang.org/std/os/windows/fs/trait.OpenOptionsExt.html#tymethod.access_mode)
+        /// Wrapper for [`std::os::windows::fs::OpenOptionsExt::access_mode`].
         fn access_mode(&mut self, access: u32) -> &mut Self;
-        /// Wrapper for [`OpenOptionsExt::share_mode`](https://doc.rust-lang.org/std/os/windows/fs/trait.OpenOptionsExt.html#tymethod.share_mode)
+        /// Wrapper for [`std::os::windows::fs::OpenOptionsExt::share_mode`].
         fn share_mode(&mut self, val: u32) -> &mut Self;
-        /// Wrapper for [`OpenOptionsExt::custom_flags`](https://doc.rust-lang.org/std/os/windows/fs/trait.OpenOptionsExt.html#tymethod.custom_flags)
+        /// Wrapper for [`std::os::windows::fs::OpenOptionsExt::custom_flags`].
         fn custom_flags(&mut self, flags: u32) -> &mut Self;
-        /// Wrapper for [`OpenOptionsExt::attributes`](https://doc.rust-lang.org/std/os/windows/fs/trait.OpenOptionsExt.html#tymethod.attributes)
+        /// Wrapper for [`std::os::windows::fs::OpenOptionsExt::attributes`].
         fn attributes(&mut self, val: u32) -> &mut Self;
-        /// Wrapper for [`OpenOptionsExt::security_qos_flags`](https://doc.rust-lang.org/std/os/windows/fs/trait.OpenOptionsExt.html#tymethod.security_qos_flags)
+        /// Wrapper for [`std::os::windows::fs::OpenOptionsExt::security_qos_flags`].
         fn security_qos_flags(&mut self, flags: u32) -> &mut Self;
     }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -4,7 +4,9 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
-/// Defines aliases on [`Path`](https://doc.rust-lang.org/std/path/struct.Path.html) for `fs_err` functions.
+use crate as fs_err; // for docs
+
+/// Defines aliases on [`std::path::Path`] for fs-err functions.
 ///
 /// This trait is sealed and can not be implemented by other crates.
 //
@@ -12,30 +14,30 @@ use std::path::{Path, PathBuf};
 pub trait PathExt: crate::Sealed {
     /// Returns Ok(true) if the path points at an existing entity.
     ///
-    /// Wrapper for [`Path::try_exists`](https://doc.rust-lang.org/std/path/struct.Path.html#method.try_exists).
+    /// Wrapper for [`std::path::Path::try_exists`].
     #[cfg(rustc_1_63)]
     fn fs_err_try_exists(&self) -> io::Result<bool>;
     /// Given a path, query the file system to get information about a file, directory, etc.
     ///
-    /// Wrapper for [`crate::metadata`].
+    /// Wrapper for [`fs_err::metadata`].
     fn fs_err_metadata(&self) -> io::Result<fs::Metadata>;
     /// Query the metadata about a file without following symlinks.
     ///
-    /// Wrapper for [`crate::symlink_metadata`].
+    /// Wrapper for [`fs_err::symlink_metadata`].
     fn fs_err_symlink_metadata(&self) -> io::Result<fs::Metadata>;
     /// Returns the canonical, absolute form of a path with all intermediate components
     /// normalized and symbolic links resolved.
     ///
-    /// Wrapper for [`crate::canonicalize`].
+    /// Wrapper for [`fs_err::canonicalize`].
     fn fs_err_canonicalize(&self) -> io::Result<PathBuf>;
     /// Reads a symbolic link, returning the file that the link points to.
     ///
-    /// Wrapper for [`crate::read_link`].
+    /// Wrapper for [`fs_err::read_link`].
     fn fs_err_read_link(&self) -> io::Result<PathBuf>;
     /// Returns an iterator over the entries within a directory.
     ///
-    /// Wrapper for [`crate::read_dir`].
-    fn fs_err_read_dir(&self) -> io::Result<crate::ReadDir>;
+    /// Wrapper for [`fs_err::read_dir`].
+    fn fs_err_read_dir(&self) -> io::Result<fs_err::ReadDir>;
 }
 
 impl PathExt for Path {
@@ -61,7 +63,7 @@ impl PathExt for Path {
         crate::read_link(self)
     }
 
-    fn fs_err_read_dir(&self) -> io::Result<crate::ReadDir> {
+    fn fs_err_read_dir(&self) -> io::Result<fs_err::ReadDir> {
         crate::read_dir(self)
     }
 }

--- a/src/tokio/dir_builder.rs
+++ b/src/tokio/dir_builder.rs
@@ -15,7 +15,7 @@ impl DirBuilder {
     /// Creates a new set of options with default mode/security settings for all
     /// platforms and also non-recursive.
     ///
-    /// This is a wrapper version of [`tokio::fs::DirBuilder::new`]
+    /// This is a wrapper version of [`tokio::fs::DirBuilder::new`].
     ///
     /// # Examples
     ///

--- a/src/tokio/file.rs
+++ b/src/tokio/file.rs
@@ -11,6 +11,9 @@ use tokio::io::{AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
 
 use super::OpenOptions;
 
+#[allow(unused_imports)]
+use crate as fs_err; // for docs
+
 /// Wrapper around [`tokio::fs::File`] which adds more helpful
 /// information to all errors.
 #[derive(Debug)]
@@ -61,7 +64,7 @@ impl File {
         OpenOptions::new()
     }
 
-    /// Converts a [`crate::File`] to a [`tokio::fs::File`].
+    /// Converts a [`fs_err::File`] to a [`fs_err::tokio::File`].
     ///
     /// Wrapper for [`tokio::fs::File::from_std`].
     pub fn from_std(std: crate::File) -> File {
@@ -122,15 +125,15 @@ impl File {
         }
     }
 
-    /// Destructures `File` into a [`crate::File`]. This function is async to allow any
-    /// in-flight operations to complete.
+    /// Destructures `File` into a [`fs_err::File`]. This function is async
+    /// to allow any in-flight operations to complete.
     ///
     /// Wrapper for [`tokio::fs::File::into_std`].
     pub async fn into_std(self) -> crate::File {
         crate::File::from_parts(self.tokio.into_std().await, self.path)
     }
 
-    /// Tries to immediately destructure `File` into a [`crate::File`].
+    /// Tries to immediately destructure `File` into a [`fs_err::File`].
     ///
     /// Wrapper for [`tokio::fs::File::try_into_std`].
     pub fn try_into_std(self) -> Result<crate::File, File> {
@@ -151,10 +154,9 @@ impl File {
     }
 }
 
-/// Methods added by fs-err that are not available on
-/// [`tokio::fs::File`].
+/// Methods added by fs-err that are not available on [`tokio::fs::File`].
 impl File {
-    /// Creates a [`File`](struct.File.html) from a raw file and its path.
+    /// Creates a [`File`] from a raw file and its path.
     pub fn from_parts<P>(file: TokioFile, path: P) -> Self
     where
         P: Into<PathBuf>,
@@ -165,7 +167,7 @@ impl File {
         }
     }
 
-    /// Extract the raw file and its path from this [`File`](struct.File.html).
+    /// Extract the raw file and its path from this [`File`].
     pub fn into_parts(self) -> (TokioFile, PathBuf) {
         (self.tokio, self.path)
     }
@@ -185,7 +187,7 @@ impl File {
         &self.path
     }
 
-    /// Wrap the error in information specific to this `File` object.
+    /// Wrap the error in information specific to this [`File`] object.
     fn error(&self, source: io::Error, kind: ErrorKind) -> io::Error {
         Error::build(source, kind, &self.path)
     }

--- a/src/tokio/mod.rs
+++ b/src/tokio/mod.rs
@@ -1,4 +1,4 @@
-//! Tokio-specific wrappers that use `fs_err` error messages.
+//! Tokio-specific wrappers that use fs-err error messages.
 
 use crate::errors::{Error, ErrorKind, SourceDestError, SourceDestErrorKind};
 use std::fs::{Metadata, Permissions};

--- a/src/tokio/open_options.rs
+++ b/src/tokio/open_options.rs
@@ -18,7 +18,7 @@ impl OpenOptions {
     ///
     /// All options are initially set to `false`.
     ///
-    /// This is a wrapped version of [`tokio::fs::OpenOptions::new`]
+    /// This is a wrapped version of [`tokio::fs::OpenOptions::new`].
     ///
     /// # Examples
     ///


### PR DESCRIPTION
This PR cleans rustdoc comments, primarily links. No code/API changes.

# Don't use http/html links

Why: these are clickable in rust-analyzer and lintable by `rust doc` (`rustdoc::broken_intra_doc_links`):
- ```rust
  /// Wrapper for [`std::fs::read_dir()`].
  ```
- ```rust
  /// Creates a [`File`] from a raw file and its path.
  ```
- ```rust
  /// This struct is created via [`fs_err::read_dir`].
  ```

These are not:
- ```rust
  /// Wrapper for [`fs::read_dir`](https://doc.rust-lang.org/stable/std/fs/fn.read_dir.html).
  ```
- ```rust
  /// Creates a [`File`](struct.File.html) from a raw file and its path.
  ```
- ```rust
  /// This struct is created via [`fs_err::read_dir`][fs_err::read_dir].
  /// [fs_err::read_dir]: fn.read_dir.html
  ```


# Other changes

- Fix typo: `seek_wriite`.
- Always spell full paths.
  - Use `` `std::fs::something` ``, not `` `fs::something` ``.
  - Use `` `fs_err::Something` ``, not `` `crate::Something` ``.
  - Why: extra clear because there are multiple similarly named structures.
- Refer to the crate as `fs-err`, not `` `fs_err` ``. That's how it's spelled in the readme.
