### PR TITLE
Fix `debug_tokio` feature to work as documented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # fs-err Changelog
 
+* Fix `debug_tokio` feature so it works as documented. ([#92](https://github.com/andrewhickman/fs-err/issues/92))
+
 ## 3.3.2
 
 * Cleanup rustdoc links to make them clickable in rust-analyzer ([#88](https://github.com/andrewhickman/fs-err/pull/88))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = "=1.0.64"
 # Note: Requires Rust 1.79+ due to path_facts dependency
 debug = ["path_facts"]
 
-debug_tokio = ["path_facts", "tokio/rt-multi-thread"]
+debug_tokio = ["debug", "tokio/rt-multi-thread"]
 
 # Allow custom formatting of the error source
 #


### PR DESCRIPTION
From the docs:

		To use with the `tokio` feature, use `debug_tokio`:

		```toml
		[dependencies]
		fs-err = { features = ["debug_tokio", "tokio"] }
		```

However, using the features shown would not add debug output while using fs-err + tokio. The problem is that internally, the logic is feature-flagged based on `debug`. The solution is to have `debug_tokio` depend on the `debug` feature rather than `path_facts`.

close #91